### PR TITLE
Update to ble api 2.0.0

### DIFF
--- a/BLE_BatteryLevel/module.json
+++ b/BLE_BatteryLevel/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "^1.0.0"
+    "ble": "^2.0.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/BLE_BatteryLevel/readme.md
+++ b/BLE_BatteryLevel/readme.md
@@ -8,7 +8,7 @@ Your BatteryLevel peripheral should be detectable by BLE scanners (e.g. a
 smartphone). To use your phone as a BLE scanner simply install one of the
 following apps:
 
-- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp).
 
 - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_BatteryLevel/source/main.cpp
+++ b/BLE_BatteryLevel/source/main.cpp
@@ -50,11 +50,17 @@ void blinkCallback(void)
     }
 }
 
+/**
+ * This function is called when the ble initialization process has failled
+ */
 void onBleInitError(BLE &ble, ble_error_t error)
 {
     // Initialization error handling should go here
 }
 
+/**
+ * Callback triggered when the ble initialization process has finished
+ */
 void bleInitComplete(BLE &ble, ble_error_t error)
 {
     if (error != BLE_ERROR_NONE) {

--- a/BLE_BatteryLevel/source/main.cpp
+++ b/BLE_BatteryLevel/source/main.cpp
@@ -50,12 +50,24 @@ void blinkCallback(void)
     }
 }
 
-void app_start(int, char**)
+void onBleInitError(BLE &ble, ble_error_t error)
 {
-    minar::Scheduler::postCallback(blinkCallback).period(minar::milliseconds(500));
+    // Initialization error handling should go here
+}
 
-    BLE &ble = BLE::Instance();
-    ble.init();
+void bleInitComplete(BLE &ble, ble_error_t error)
+{
+    if (error != BLE_ERROR_NONE) {
+        // in case of error, forward the error handling to onBleInitError
+        onBleInitError(ble, error);
+        return;
+    }
+
+    // ensure that it is the default instance of BLE
+    if(ble.getInstanceID() != BLE::DEFAULT_INSTANCE) {
+        return;
+    }
+
     ble.gap().onDisconnection(disconnectionCallback);
 
     /* Setup primary service */
@@ -68,4 +80,12 @@ void app_start(int, char**)
     ble.gap().setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);
     ble.gap().setAdvertisingInterval(1000); /* 1000ms */
     ble.gap().startAdvertising();
+}
+
+void app_start(int, char**)
+{
+    minar::Scheduler::postCallback(blinkCallback).period(minar::milliseconds(500));
+
+    BLE &ble = BLE::Instance();
+    ble.init(bleInitComplete);
 }

--- a/BLE_Beacon/module.json
+++ b/BLE_Beacon/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "^1.0.0"
+    "ble": "^2.0.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/BLE_Beacon/readme.md
+++ b/BLE_Beacon/readme.md
@@ -13,7 +13,7 @@ To get this going, you’ll need:
 
 - One of the generic apps to scan BLE peripherals.
 
-  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp).
 
   - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_Beacon/source/main.cpp
+++ b/BLE_Beacon/source/main.cpp
@@ -20,9 +20,23 @@
 
 BLE ble;
 
-void app_start(int argc, char *argv[])
+void onBleInitError(BLE &ble, ble_error_t error)
 {
-    ble.init();
+    // Initialization error handling should go here
+}
+
+void bleInitComplete(BLE &ble, ble_error_t error)
+{
+    if (error != BLE_ERROR_NONE) {
+        // in case of error, forward the error handling to onBleInitError
+        onBleInitError(ble, error);
+        return;
+    }
+
+    // ensure that it is the default instance of BLE
+    if(ble.getInstanceID() != BLE::DEFAULT_INSTANCE) {
+        return;
+    }
 
     /**
      * The Beacon payload has the following composition:
@@ -41,4 +55,9 @@ void app_start(int argc, char *argv[])
 
     ble.gap().setAdvertisingInterval(1000); /* 1000ms. */
     ble.gap().startAdvertising();
+}
+
+void app_start(int argc, char *argv[])
+{
+    ble.init(bleInitComplete);
 }

--- a/BLE_Beacon/source/main.cpp
+++ b/BLE_Beacon/source/main.cpp
@@ -20,11 +20,17 @@
 
 BLE ble;
 
+/**
+ * This function is called when the ble initialization process has failled
+ */
 void onBleInitError(BLE &ble, ble_error_t error)
 {
     // Initialization error handling should go here
 }
 
+/**
+ * Callback triggered when the ble initialization process has finished
+ */
 void bleInitComplete(BLE &ble, ble_error_t error)
 {
     if (error != BLE_ERROR_NONE) {

--- a/BLE_Button/module.json
+++ b/BLE_Button/module.json
@@ -10,6 +10,6 @@
   ],
   "bin": "./source",
   "dependencies": {
-    "ble": "^1.0.0"
+    "ble": "^2.0.0"
   }
 }

--- a/BLE_Button/readme.md
+++ b/BLE_Button/readme.md
@@ -17,7 +17,7 @@ Checking for Success
 Your Button peripheral should be detectable by BLE scanners (e.g. a smartphone).
 To use your phone as a BLE scanner simply install one of the following apps:
 
-- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp).
 
 - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_EddystoneBeacon/module.json
+++ b/BLE_EddystoneBeacon/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "^1.0.0"
+    "ble": "^2.0.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/BLE_EddystoneBeacon/readme.md
+++ b/BLE_EddystoneBeacon/readme.md
@@ -13,7 +13,7 @@ To get this going, you’ll need:
 
   - The `physical web` app. You can get that app for [iOS](https://itunes.apple.com/us/app/physical-web/id927653608?mt=8) and for [Android](https://play.google.com/store/apps/details?id=physical_web.org.physicalweb).
 
-  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp).
 
   - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_EddystoneBeacon/source/main.cpp
+++ b/BLE_EddystoneBeacon/source/main.cpp
@@ -48,11 +48,17 @@ void tlmTemperatureCallback(void){
     eddyBeaconPtr->updateTlmBeaconTemp(temp++);
 }
 
+/**
+ * This function is called when the ble initialization process has failled
+ */
 void onBleInitError(BLE &ble, ble_error_t error)
 {
     // Initialization error handling should go here
 }
 
+/**
+ * Callback triggered when the ble initialization process has finished
+ */
 void bleInitComplete(BLE &ble, ble_error_t error)
 {
     if (error != BLE_ERROR_NONE) {

--- a/BLE_EddystoneBeaconConfigService/module.json
+++ b/BLE_EddystoneBeaconConfigService/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "^1.0.0"
+    "ble": "^2.0.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/BLE_EddystoneBeaconConfigService/readme.md
+++ b/BLE_EddystoneBeaconConfigService/readme.md
@@ -18,7 +18,7 @@ To get this going, you’ll need:
 
   - The `physical web` app. You can get that app for [iOS](https://itunes.apple.com/us/app/physical-web/id927653608?mt=8) and for [Android](https://play.google.com/store/apps/details?id=physical_web.org.physicalweb).
 
-  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp).
 
   - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 


### PR DESCRIPTION
The following examples have been updated to match BLE API v2.0.0:
  * BLE_BatteryLevel
  * BLE_Beacon
  * BLE_Button
  * BLE_EddystoneBeacon
  * BLE_EddystoneBeaconConfigService

The changes for each of these examples are: 
      * Update ble dependency to version 2.0.0
      * Apply the modification for the BLE::init function
      * Update link to nRF Master Control Panel
