### PR TITLE
Updated examples to comply with BLE API 2.0.0

### DIFF
--- a/BLE_BatteryLevel/readme.md
+++ b/BLE_BatteryLevel/readme.md
@@ -8,7 +8,7 @@ Your BatteryLevel peripheral should be detectable by BLE scanners (e.g. a
 smartphone). To use your phone as a BLE scanner simply install one of the
 following apps:
 
-- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en).
 
 - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_Beacon/readme.md
+++ b/BLE_Beacon/readme.md
@@ -13,7 +13,7 @@ To get this going, you’ll need:
 
 - One of the generic apps to scan BLE peripherals.
 
-  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en).
 
   - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_Button/readme.md
+++ b/BLE_Button/readme.md
@@ -17,7 +17,7 @@ Checking for Success
 Your Button peripheral should be detectable by BLE scanners (e.g. a smartphone).
 To use your phone as a BLE scanner simply install one of the following apps:
 
-- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en).
 
 - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_EddystoneBeacon/readme.md
+++ b/BLE_EddystoneBeacon/readme.md
@@ -13,7 +13,7 @@ To get this going, you’ll need:
 
   - The `physical web` app. You can get that app for [iOS](https://itunes.apple.com/us/app/physical-web/id927653608?mt=8) and for [Android](https://play.google.com/store/apps/details?id=physical_web.org.physicalweb).
 
-  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en).
 
   - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_EddystoneBeaconConfigService/readme.md
+++ b/BLE_EddystoneBeaconConfigService/readme.md
@@ -18,7 +18,7 @@ To get this going, you’ll need:
 
   - The `physical web` app. You can get that app for [iOS](https://itunes.apple.com/us/app/physical-web/id927653608?mt=8) and for [Android](https://play.google.com/store/apps/details?id=physical_web.org.physicalweb).
 
-  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en).
 
   - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_EddystoneObserver/module.json
+++ b/BLE_EddystoneObserver/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "^1.0.0"
+    "ble": "^2.0.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/BLE_EddystoneObserver/source/main.cpp
+++ b/BLE_EddystoneObserver/source/main.cpp
@@ -115,12 +115,29 @@ void advertisementCallback(const Gap::AdvertisementCallbackParams_t *params)
     }
 }
 
+void onBleInitError(BLE &ble, ble_error_t error)
+{
+   /* Initialization error handling should go here */
+}
+
+void bleInitComplete(BLE &ble, ble_error_t error)
+{
+    if (error != BLE_ERROR_NONE) {
+        onBleInitError(ble, error);
+        return;
+    }
+
+    if (ble.getInstanceID() != BLE::DEFAULT_INSTANCE) {
+        return;
+    }
+
+    ble.gap().setScanParams(1800 /* scan interval */, 1500 /* scan window */);
+    ble.gap().startScan(advertisementCallback);
+}
+
 void app_start(int, char *[])
 {
     minar::Scheduler::postCallback(periodicCallback).period(minar::milliseconds(500));
 
-    BLE &ble = BLE::Instance();
-    ble.init();
-    ble.gap().setScanParams(1800 /* scan interval */, 1500 /* scan window */);
-    ble.gap().startScan(advertisementCallback);
+    BLE::Instance().init(bleInitComplete);
 }

--- a/BLE_HeartRate/module.json
+++ b/BLE_HeartRate/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "^1.0.0"
+    "ble": "^2.0.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/BLE_HeartRate/readme.md
+++ b/BLE_HeartRate/readme.md
@@ -16,12 +16,12 @@ To get this going, you’ll need:
 
 - You could also use one of the generic apps to scan BLE peripherals.
 
-  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en).
 
   - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 
 - One of the BLE platforms listed in the README.md of this repository, for example a
-  Nordic DK board. 
+  Nordic DK board.
 
 Build Instructions
 ==================

--- a/BLE_LEDBlinker/module.json
+++ b/BLE_LEDBlinker/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "^1.0.0"
+    "ble": "^2.0.0"
   },
   "bin": "./source"
 }

--- a/BLE_LEDBlinker/source/main.cpp
+++ b/BLE_LEDBlinker/source/main.cpp
@@ -108,13 +108,22 @@ void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *) {
     BLE::Instance().gap().startScan(advertisementCallback);
 }
 
-void app_start(int, char**) {
-    triggerLedCharacteristic = false;
+void onBleInitError(BLE &ble, ble_error_t error)
+{
+   /* Initialization error handling should go here */
+}
 
-    minar::Scheduler::postCallback(periodicCallback).period(minar::milliseconds(500));
+void bleInitComplete(BLE &ble, ble_error_t error)
+{
+    if (error != BLE_ERROR_NONE) {
+        onBleInitError(ble, error);
+        return;
+    }
 
-    BLE &ble = BLE::Instance();
-    ble.init();
+    if (ble.getInstanceID() != BLE::DEFAULT_INSTANCE) {
+        return;
+    }
+
     ble.gap().onDisconnection(disconnectionCallback);
     ble.gap().onConnection(connectionCallback);
 
@@ -123,4 +132,12 @@ void app_start(int, char**) {
 
     ble.gap().setScanParams(500, 400);
     ble.gap().startScan(advertisementCallback);
+}
+
+void app_start(int, char**) {
+    triggerLedCharacteristic = false;
+
+    minar::Scheduler::postCallback(periodicCallback).period(minar::milliseconds(500));
+
+    BLE::Instance().init(bleInitComplete);
 }

--- a/BLE_Thermometer/module.json
+++ b/BLE_Thermometer/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "^1.0.0"
+    "ble": "^2.0.0"
   },
   "bin": "./source"
 }

--- a/BLE_Thermometer/readme.md
+++ b/BLE_Thermometer/readme.md
@@ -15,7 +15,7 @@ Your Health Thermometer peripheral should be detectable by BLE scanners (e.g. a
 smartphone). To use your phone as a BLE scanner simply install one of the
 following apps:
 
-- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en).
 
 - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_Thermometer/source/main.cpp
+++ b/BLE_Thermometer/source/main.cpp
@@ -43,17 +43,27 @@ void periodicCallback(void)
 {
     led1 = !led1; /* Do blinky on LED1 while we're waiting for BLE events */
 
-    if (BLE::Instance().getGapState().connected) {
+    if (BLE::Instance().gap().getState().connected) {
         minar::Scheduler::postCallback(updateSensorValue);
     }
 }
 
-void app_start(int, char**)
+void onBleInitError(BLE &ble, ble_error_t error)
 {
-    minar::Scheduler::postCallback(periodicCallback).period(minar::milliseconds(500));
+   /* Initialization error handling should go here */
+}
 
-    BLE &ble = BLE::Instance();
-    ble.init();
+void bleInitComplete(BLE &ble, ble_error_t error)
+{
+    if (error != BLE_ERROR_NONE) {
+        onBleInitError(ble, error);
+        return;
+    }
+
+    if (ble.getInstanceID() != BLE::DEFAULT_INSTANCE) {
+        return;
+    }
+
     ble.gap().onDisconnection(disconnectionCallback);
 
     /* Setup primary service. */
@@ -67,4 +77,11 @@ void app_start(int, char**)
     ble.gap().setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);
     ble.gap().setAdvertisingInterval(1000); /* 1000ms */
     ble.gap().startAdvertising();
+}
+
+void app_start(int, char**)
+{
+    minar::Scheduler::postCallback(periodicCallback).period(minar::milliseconds(500));
+
+    BLE::Instance().init(bleInitComplete);
 }

--- a/BLE_URIBeacon/module.json
+++ b/BLE_URIBeacon/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "^2.0.0"
+    "ble": "^1.0.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/BLE_URIBeacon/module.json
+++ b/BLE_URIBeacon/module.json
@@ -9,7 +9,7 @@
     }
   ],
   "dependencies": {
-    "ble": "ARMmbed/ble"
+    "ble": "^2.0.0"
   },
   "targetDependencies": {},
   "bin": "./source"

--- a/BLE_URIBeacon/readme.md
+++ b/BLE_URIBeacon/readme.md
@@ -15,7 +15,7 @@ To get this going, you’ll need:
 
   - The `physical web` app. You can get that app for [iOS](https://itunes.apple.com/us/app/physical-web/id927653608?mt=8) and for [Android](https://play.google.com/store/apps/details?id=physical_web.org.physicalweb).
 
-  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+  - For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en).
 
   - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 

--- a/BLE_URIBeacon/source/main.cpp
+++ b/BLE_URIBeacon/source/main.cpp
@@ -33,7 +33,6 @@
 static const int CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS = 60;  // Duration after power-on that config service is available.
 
 /* global static objects */
-BLE ble;
 URIBeaconConfigService *uriBeaconConfig;
 URIBeaconConfigService::Params_t params;
 
@@ -42,11 +41,14 @@ URIBeaconConfigService::Params_t params;
  */
 void timeout(void)
 {
+    BLE &ble = BLE::Instance();
     Gap::GapState_t state;
-    state = ble.getGapState();
+    state = ble.gap().getState();
     if (!state.connected) { /* don't switch if we're in a connected state. */
         uriBeaconConfig->setupURIBeaconAdvertisements();
-        ble.startAdvertising();
+        ble.gap().startAdvertising();
+    } else {
+        minar::Scheduler::postCallback(timeout).delay(minar::milliseconds(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000));
     }
 }
 
@@ -55,13 +57,26 @@ void timeout(void)
  */
 void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *)
 {
-    ble.startAdvertising();
+    BLE::Instance().gap().startAdvertising();
 }
 
-void app_start(int, char *[])
+void onBleInitError(BLE &ble, ble_error_t error)
 {
-    ble.init();
-    ble.onDisconnection(disconnectionCallback);
+   /* Initialization error handling should go here */
+}
+
+void bleInitComplete(BLE &ble, ble_error_t error)
+{
+    if (error != BLE_ERROR_NONE) {
+        onBleInitError(ble, error);
+        return;
+    }
+
+    if (ble.getInstanceID() != BLE::DEFAULT_INSTANCE) {
+        return;
+    }
+
+    ble.gap().onDisconnection(disconnectionCallback);
 
     /*
      * Load parameters from (platform specific) persistent storage. Parameters
@@ -76,16 +91,21 @@ void app_start(int, char *[])
     static URIBeaconConfigService::PowerLevels_t defaultAdvPowerLevels = {-20, -4, 0, 10}; // Values for ADV packets related to firmware levels
     uriBeaconConfig = new URIBeaconConfigService(ble, params, !fetchedFromPersistentStorage, "http://uribeacon.org", defaultAdvPowerLevels);
     if (!uriBeaconConfig->configuredSuccessfully()) {
-        error("failed to accommodate URI");
+        return;
     }
 
     // Setup auxiliary services to allow over-the-air firmware updates, etc
     DFUService *dfu = new DFUService(ble);
     DeviceInformationService *deviceInfo = new DeviceInformationService(ble, "ARM", "UriBeacon", "SN1", "hw-rev1", "fw-rev1", "soft-rev1");
 
-    ble.startAdvertising(); /* Set the whole thing in motion. After this call a GAP central can scan the URIBeaconConfig
+    ble.gap().startAdvertising(); /* Set the whole thing in motion. After this call a GAP central can scan the URIBeaconConfig
                              * service. This can then be switched to the normal URIBeacon functionality after a timeout. */
 
     /* Post a timeout callback to be invoked in ADVERTISEMENT_TIMEOUT_SECONDS to affect the switch to beacon mode. */
     minar::Scheduler::postCallback(timeout).delay(minar::milliseconds(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000));
+}
+
+void app_start(int, char *[])
+{
+    BLE::Instance().init(bleInitComplete);
 }

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ or beacon information, get one of the following installed on your phone:
 - The `physical web` app. You can get that app for [iOS](https://itunes.apple.com/us/app/physical-web/id927653608?mt=8) and for [Android](https://play.google.com/store/apps/details?id=physical_web.org.physicalweb).
   *Only useful to see beacons advertising URLs*
 
-- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/detailsid=no.nordicsemi.android.mcp&hl=en).
+- For Android, you can get [nRF Master Control Panel](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en).
 
 - For iPhone, you can get [LightBlue](https://itunes.apple.com/gb/app/lightblue-bluetooth-low-energy/id557428110?mt=8).
 
@@ -144,13 +144,13 @@ sources which get picked up automatically for builds--in the case of
 BLE_BEacon, there's a `main.cpp` under its `source/`.
 
 More can be learnt about yotta from [this
-tutorial](http://docs.yottabuild.org/tutorial/tutorial.html).
+tutorial](http://yottadocs.mbed.com/).
 
 
 Creating new BLE yotta application-modules
 ------------------------------------------
 
-Please refer to yotta documentation on [creating an executable](http://docs.yottabuild.org/tutorial/tutorial.html#Creating%20an%20Executable).
+Please refer to yotta documentation on [creating an executable](http://yottadocs.mbed.com/tutorial/tutorial.html#Creating%20an%20Executable).
 BLE applications would typically depend on the `ble` module to use
 [BLE API](https://github.com/ARMmbed/ble), as can be seen from https://github.com/ARMmbed/ble-examples/blob/master/BLE_Beacon/module.json#L13.
 Applications would also need the mbed-drivers module to bring in mbed OS APIs, minar, and capabilities of the target platform.


### PR DESCRIPTION
Updated BLE_LEDBlink, BLE_HeartRate, BLE_Thermometer and BLE_EddystoneObserver to comply with the latest init change introduced in BLE API 2.0.0. Also, updated readme files that contained broken links.

Note that changes to BLE_URIBeacon example were reversed after the application showed incorrect behaviour with BLE API 2.0.0.