### PR TITLE
Add experimental EddystoneService

### DIFF
--- a/BLE_EddystoneServiceExperimental/config.json
+++ b/BLE_EddystoneServiceExperimental/config.json
@@ -1,0 +1,8 @@
+{
+  "nordic": {
+    "softdevice": "S110"
+  },
+  "mbed": {
+    "max-filehandles": 4
+  }
+}

--- a/BLE_EddystoneServiceExperimental/config.json
+++ b/BLE_EddystoneServiceExperimental/config.json
@@ -1,6 +1,6 @@
 {
   "nordic": {
-    "softdevice": "S110"
+    "softdevice": "S130"
   },
   "mbed": {
     "max-filehandles": 4

--- a/BLE_EddystoneServiceExperimental/module.json
+++ b/BLE_EddystoneServiceExperimental/module.json
@@ -1,0 +1,16 @@
+{
+  "name": "ble-eddystonebeaconexperimental",
+  "version": "0.0.1",
+  "description": "This example demonstrates how to set up and initialize a Eddystone Beacon.",
+  "licenses": [
+    {
+      "url": "https://spdx.org/licenses/Apache-2.0",
+      "type": "Apache-2.0"
+    }
+  ],
+  "dependencies": {
+    "ble": "^2.0.0"
+  },
+  "targetDependencies": {},
+  "bin": "./source"
+}

--- a/BLE_EddystoneServiceExperimental/source/ConfigParamsPersistence.h
+++ b/BLE_EddystoneServiceExperimental/source/ConfigParamsPersistence.h
@@ -1,0 +1,52 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __BLE_CONFIG_PARAMS_PERSISTENCE_H__
+#define __BLE_CONFIG_PARAMS_PERSISTENCE_H__
+
+#include "EddystoneService.h"
+
+/**
+ * Generic API to load the URIBeacon configuration parameters from persistent
+ * storage. If persistent storage isn't available, the persistenceSignature
+ * member of params may be left un-initialized to the MAGIC, and this will cause
+ * a reset to default values.
+ *
+ * @param[out] paramsP
+ *                 The parameters to be filled in from persistence storage. This
+                   argument can be NULL if the caller is only interested in
+                   discovering the persistence status of params.
+ * @return true if params were loaded from persistent storage and have usefully
+ *         initialized fields.
+ */
+bool loadURIBeaconConfigParams(EddystoneService::EddystoneParams_t *paramsP);
+
+/**
+ * Generic API to store the URIBeacon configuration parameters to persistent
+ * storage. It typically initializes the persistenceSignature member of the
+ * params to the MAGIC value to indicate persistence.
+ *
+ * @note: the save operation may be asynchronous. It may be a short while before
+ * the request takes affect. Reading back saved configParams may not yield
+ * correct behaviour if attempted soon after a store.
+ *
+ * @param[in/out] paramsP
+ *                    The params to be saved; persistenceSignature member gets
+ *                    updated if persistence is successful.
+ */
+void saveURIBeaconConfigParams(const EddystoneService::EddystoneParams_t *paramsP);
+
+#endif /* #ifndef __BLE_CONFIG_PARAMS_PERSISTENCE_H__*/

--- a/BLE_EddystoneServiceExperimental/source/EddystoneService.h
+++ b/BLE_EddystoneServiceExperimental/source/EddystoneService.h
@@ -472,7 +472,6 @@ private:
          * the advertisement period is consistent
          */
         ble.gap().stopAdvertising();
-        swapAdvertisedFrame();
         stopAdv.attach_us(this, &EddystoneService::swapAdvertisedFrame, beaconPeriod * 1000);
     }
 

--- a/BLE_EddystoneServiceExperimental/source/EddystoneService.h
+++ b/BLE_EddystoneServiceExperimental/source/EddystoneService.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef SERVICES_EDDYSTONEBEACON_H_
-#define SERVICES_EDDYSTONEBEACON_H_
+#ifndef __EDDYSTONESERVICE_H__
+#define __EDDYSTONESERVICE_H__
 
 #include "ble/BLE.h"
 #include "mbed-drivers/mbed.h"
@@ -92,25 +92,23 @@ public:
 
     static const uint16_t DEFAULT_BEACON_PERIOD_MSEC = 1000;
 
-    // Maximum size of service data in ADV packets
-    static const uint16_t MAX_ADV_PACKET_SIZE       = 31;
-
-    typedef uint8_t Lock_t[16];                             /* 128 bits */
+    /* 128 bits of lock */
+    typedef uint8_t Lock_t[16];
     typedef int8_t PowerLevels_t[NUM_POWER_MODES];
 
     static const uint16_t URL_DATA_MAX = 18;
     typedef uint8_t UrlData_t[URL_DATA_MAX];
 
-    // UID Frame Type subfields
+    /* UID Frame Type subfields */
     static const size_t UID_NAMESPACEID_SIZE = 10;
     typedef uint8_t UIDNamespaceID_t[UID_NAMESPACEID_SIZE];
     static const size_t UID_INSTANCEID_SIZE = 6;
     typedef uint8_t UIDInstanceID_t[UID_INSTANCEID_SIZE];
 
-    // Callbacks for updating BateryVoltage and Temperature
+    /* Callbacks for updating BateryVoltage and Temperature */
     typedef uint16_t (*TlmUpdateCallback_t) (uint16_t);
 
-    // Size of Eddystone UUID needed for all frames
+    /* Size of Eddystone UUID needed for all frames */
     static const uint16_t EDDYSTONE_UUID_SIZE = sizeof(EDDYSTONE_UUID);
 
     static const uint16_t TOTAL_CHARACTERISTICS = 9;
@@ -674,14 +672,14 @@ private:
         return beaconPeriodIn;
     }
 
-    struct TLMFrameFactory
+    struct TLMFrame
     {
     public:
-        TLMFrameFactory(uint8_t  tlmVersionIn           = 0,
-                        uint16_t tlmBatteryVoltageIn    = 0,
-                        uint16_t tlmBeaconTemperatureIn = 0x8000,
-                        uint32_t tlmPduCountIn          = 0,
-                        uint32_t tlmTimeSinceBootIn     = 0) :
+        TLMFrame(uint8_t  tlmVersionIn           = 0,
+                 uint16_t tlmBatteryVoltageIn    = 0,
+                 uint16_t tlmBeaconTemperatureIn = 0x8000,
+                 uint32_t tlmPduCountIn          = 0,
+                 uint32_t tlmTimeSinceBootIn     = 0) :
             tlmVersion(tlmVersionIn),
             lastTimeSinceBootRead(0),
             tlmBatteryVoltage(tlmBatteryVoltageIn),
@@ -778,16 +776,16 @@ private:
         uint32_t             tlmTimeSinceBoot;
     };
 
-    class UIDFrameFactory
+    class UIDFrame
     {
     public:
-        UIDFrameFactory(void)
+        UIDFrame(void)
         {
             memset(uidNamespaceID, 0, sizeof(UIDNamespaceID_t));
             memset(uidInstanceID,  0,  sizeof(UIDInstanceID_t));
         }
 
-        UIDFrameFactory(const UIDNamespaceID_t uidNamespaceIDIn,
+        UIDFrame(const UIDNamespaceID_t uidNamespaceIDIn,
                         const UIDInstanceID_t  uidInstanceIDIn)
         {
             memcpy(uidNamespaceID, uidNamespaceIDIn, sizeof(UIDNamespaceID_t));
@@ -844,21 +842,21 @@ private:
         UIDInstanceID_t      uidInstanceID;
     };
 
-    struct URLFrameFactory
+    struct URLFrame
     {
     public:
-        URLFrameFactory(void)
+        URLFrame(void)
         {
             urlDataLength = 0;
             memset(urlData, 0, sizeof(UrlData_t));
         }
 
-        URLFrameFactory(const char *urlDataIn)
+        URLFrame(const char *urlDataIn)
         {
             encodeURL(urlDataIn);
         }
 
-        URLFrameFactory(UrlData_t urlDataIn, uint8_t urlDataLength)
+        URLFrame(UrlData_t urlDataIn, uint8_t urlDataLength)
         {
             if (urlDataLength > URL_DATA_MAX) {
                 memcpy(urlData, urlDataIn, URL_DATA_MAX);
@@ -984,9 +982,9 @@ private:
     uint32_t                                                        advConfigInterval;
     uint8_t                                                         operationMode;
 
-    URLFrameFactory                                                 urlFrame;
-    UIDFrameFactory                                                 uidFrame;
-    TLMFrameFactory                                                 tlmFrame;
+    URLFrame                                                        urlFrame;
+    UIDFrame                                                        uidFrame;
+    TLMFrame                                                        tlmFrame;
 
     PowerLevels_t                                                   radioPowerLevels;
     PowerLevels_t                                                   advPowerLevels;
@@ -1026,4 +1024,4 @@ private:
     GattCharacteristic                                              *charTable[TOTAL_CHARACTERISTICS];
 };
 
-#endif  // SERVICES_EDDYSTONEBEACON_H_
+#endif  /* __EDDYSTONESERVICE_H__ */

--- a/BLE_EddystoneServiceExperimental/source/EddystoneService.h
+++ b/BLE_EddystoneServiceExperimental/source/EddystoneService.h
@@ -1,0 +1,1014 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef SERVICES_EDDYSTONEBEACON_H_
+#define SERVICES_EDDYSTONEBEACON_H_
+
+#include "ble/BLE.h"
+#include "stdio.h"
+#include "mbed.h"
+
+#define UUID_URL_BEACON(FIRST, SECOND) {                         \
+        0xee, 0x0c, FIRST, SECOND, 0x87, 0x86, 0x40, 0xba,       \
+        0xab, 0x96, 0x99, 0xb9, 0x1a, 0xc9, 0x81, 0xd8,          \
+}
+
+static const uint8_t EDDYSTONE_UUID[] = {0xAA, 0xFE};
+
+static const uint8_t UUID_URL_BEACON_SERVICE[]    = UUID_URL_BEACON(0x20, 0x80);
+static const uint8_t UUID_LOCK_STATE_CHAR[]       = UUID_URL_BEACON(0x20, 0x81);
+static const uint8_t UUID_LOCK_CHAR[]             = UUID_URL_BEACON(0x20, 0x82);
+static const uint8_t UUID_UNLOCK_CHAR[]           = UUID_URL_BEACON(0x20, 0x83);
+static const uint8_t UUID_URL_DATA_CHAR[]         = UUID_URL_BEACON(0x20, 0x84);
+static const uint8_t UUID_FLAGS_CHAR[]            = UUID_URL_BEACON(0x20, 0x85);
+static const uint8_t UUID_ADV_POWER_LEVELS_CHAR[] = UUID_URL_BEACON(0x20, 0x86);
+static const uint8_t UUID_TX_POWER_MODE_CHAR[]    = UUID_URL_BEACON(0x20, 0x87);
+static const uint8_t UUID_BEACON_PERIOD_CHAR[]    = UUID_URL_BEACON(0x20, 0x88);
+static const uint8_t UUID_RESET_CHAR[]            = UUID_URL_BEACON(0x20, 0x89);
+
+const char DEVICE_NAME[] = "EDDYSTONE CONFIG";
+
+const char DEFAULT_URL[] = "http://www.mbed.com/";
+
+class EddystoneService
+{
+public:
+    enum {
+        TX_POWER_MODE_LOWEST,
+        TX_POWER_MODE_LOW,
+        TX_POWER_MODE_MEDIUM,
+        TX_POWER_MODE_HIGH,
+        NUM_POWER_MODES
+    };
+
+    /* Operation modes of the EddystoneService:
+     *      NONE: EddystoneService has been initialised but no memory has been
+     *            dynamically allocated. Additionally, no services are running
+     *            nothing is being advertised.
+     *      CONFIG: EddystoneService has been initialised, the configuration
+     *              service started and memory has been allocated for BLE
+     *              characteristics. Memory consumption peaks during CONFIG
+     *              mode.
+     *      BEACON: Eddystone service is running as a beacon advertising URL,
+     *              UID and/or TLM frames depending on how it is configured.
+     * Note: The main app can change the mode of EddystoneService at any point
+     * of time by calling startConfigService() or startBeaconService().
+     * Resources from the previous mode will be freed. It is currently NOT
+     * possible to force EddystoneService back into MODE_NONE.
+     */
+    enum OperationModes {
+        EDDYSTONE_MODE_NONE,
+        EDDYSTONE_MODE_CONFIG,
+        EDDYSTONE_MODE_BEACON
+    };
+
+    enum FrameType {
+        EDDYSTONE_FRAME_URL,
+        EDDYSTONE_FRAME_UID,
+        EDDYSTONE_FRAME_TLM,
+        NUM_EDDYSTONE_FRAMES
+    };
+
+    static const uint32_t DEFAULT_CONFIG_PERIOD_MSEC = 1000;
+
+    static const uint16_t DEFAULT_BEACON_PERIOD_MSEC = 1000;
+
+    // Maximum size of service data in ADV packets
+    static const uint16_t MAX_ADV_PACKET_SIZE       = 31;
+
+    typedef uint8_t Lock_t[16];                             /* 128 bits */
+    typedef int8_t PowerLevels_t[NUM_POWER_MODES];
+
+    static const uint16_t URL_DATA_MAX = 18;
+    typedef uint8_t UrlData_t[URL_DATA_MAX];
+
+    // UID Frame Type subfields
+    static const size_t UID_NAMESPACEID_SIZE = 10;
+    typedef uint8_t UIDNamespaceID_t[UID_NAMESPACEID_SIZE];
+    static const size_t UID_INSTANCEID_SIZE = 6;
+    typedef uint8_t UIDInstanceID_t[UID_INSTANCEID_SIZE];
+
+    // Callbacks for updating BateryVoltage and Temperature
+    typedef uint16_t (*TlmUpdateCallback_t) (uint16_t);
+
+    // Size of Eddystone UUID needed for all frames
+    static const uint16_t EDDYSTONE_UUID_SIZE = sizeof(EDDYSTONE_UUID);
+
+    static const uint16_t TOTAL_CHARACTERISTICS = 9;
+
+    struct EddystoneParams_t {
+        bool             lockState;
+        Lock_t           lock;
+        Lock_t           unlock;
+        uint8_t          flags;
+        PowerLevels_t    advPowerLevels;
+        uint8_t          txPowerMode;
+        uint16_t         beaconPeriod;
+        uint8_t          tlmVersion;
+        uint8_t          urlDataLength;
+        UrlData_t        urlData;
+        UIDNamespaceID_t uidNamespaceID;
+        UIDInstanceID_t  uidInstanceID;
+    };
+
+    /* Initialise the EddystoneService using parameters from persistent storage */
+    EddystoneService(BLE               &bleIn,
+                     EddystoneParams_t &paramsIn,
+                     PowerLevels_t     &advPowerLevelsIn,
+                     PowerLevels_t     &radioPowerLevelsIn,
+                     uint32_t          advConfigIntervalIn = DEFAULT_CONFIG_PERIOD_MSEC) :
+        ble(bleIn),
+        operationMode(EDDYSTONE_MODE_NONE),
+        urlFrame(paramsIn.urlData, paramsIn.urlDataLength),
+        uidFrame(paramsIn.uidNamespaceID, paramsIn.uidInstanceID),
+        tlmFrame(paramsIn.tlmVersion),
+        resetFlag(false),
+        tlmBatteryVoltageCallback(NULL),
+        tlmBeaconTemperatureCallback(NULL)
+    {
+        advConfigInterval = (advConfigIntervalIn > 0) ? checkBeaconPeriodBounds(advConfigIntervalIn) : 0;
+        lockState         = paramsIn.lockState;
+        flags             = paramsIn.flags;
+        txPowerMode       = paramsIn.txPowerMode;
+        beaconPeriod      = checkBeaconPeriodBounds(paramsIn.beaconPeriod);
+
+        memcpy(radioPowerLevels, radioPowerLevelsIn, sizeof(PowerLevels_t));
+        memcpy(advPowerLevels,   advPowerLevelsIn,   sizeof(PowerLevels_t));
+        memcpy(lock,             paramsIn.lock,      sizeof(Lock_t));
+        memcpy(unlock,           paramsIn.unlock,    sizeof(Lock_t));
+
+        /* TODO: Note that this timer is started from the time EddystoneService
+         * is initialised and NOT from when the device is booted. So app need
+         * to take care that EddystoneServices is one of the first things to be
+         * started!
+         */
+        timeSinceBootTimer.start();
+    }
+
+    /* When using this constructor we need to call setURLData,
+     * setTMLData and setUIDData to initialise values manually
+     */
+    EddystoneService(BLE               &bleIn,
+                     PowerLevels_t     &advPowerLevelsIn,
+                     PowerLevels_t     &radioPowerLevelsIn,
+                     uint32_t          advConfigIntervalIn = DEFAULT_CONFIG_PERIOD_MSEC) :
+        ble(bleIn),
+        operationMode(EDDYSTONE_MODE_NONE),
+        urlFrame(),
+        uidFrame(),
+        tlmFrame(),
+        lockState(false),
+        resetFlag(false),
+        lock(),
+        unlock(),
+        flags(0),
+        txPowerMode(0),
+        beaconPeriod(DEFAULT_BEACON_PERIOD_MSEC),
+        tlmBatteryVoltageCallback(NULL),
+        tlmBeaconTemperatureCallback(NULL)
+    {
+        advConfigInterval = (advConfigIntervalIn > 0) ? checkBeaconPeriodBounds(advConfigIntervalIn) : 0;
+
+        memcpy(radioPowerLevels, radioPowerLevelsIn, sizeof(PowerLevels_t));
+        memcpy(advPowerLevels,   advPowerLevelsIn,   sizeof(PowerLevels_t));
+
+        /* TODO: Note that this timer is started from the time EddystoneService
+         * is initialised and NOT from when the device is booted. So app need
+         * to take care that EddystoneServices is one of the first things to be
+         * started!
+         */
+        timeSinceBootTimer.start();
+    }
+
+    /* Setup callback to update BatteryVoltage in TLM frame */
+    void onTLMBatteryVoltageUpdate(TlmUpdateCallback_t tlmBatteryVoltageCallbackIn)
+    {
+        tlmBatteryVoltageCallback = tlmBatteryVoltageCallbackIn;
+    }
+
+    /* Setup callback to update BeaconTemperature in TLM frame */
+    void onTLMBeaconTemperatureUpdate(TlmUpdateCallback_t tlmBeaconTemperatureCallbackIn)
+    {
+        tlmBeaconTemperatureCallback = tlmBeaconTemperatureCallbackIn;
+    }
+
+    void setTLMData(uint8_t tlmVersionIn = 0)
+    {
+       tlmFrame.setTLMData(tlmVersionIn);
+    }
+
+    void setURLData(const char *urlDataIn)
+    {
+        urlFrame.setURLData(urlDataIn);
+    }
+
+    void setUIDData(UIDNamespaceID_t *uidNamespaceIDIn, UIDInstanceID_t *uidInstanceIDIn)
+    {
+        uidFrame.setUIDData(uidNamespaceIDIn, uidInstanceIDIn);
+    }
+
+    void startConfigService(void)
+    {
+        if (operationMode == EDDYSTONE_MODE_CONFIG) {
+            /* Nothing to do, we are already in config mode */
+            return;
+        } else if (advConfigInterval == 0) {
+            /* Nothing to do, the advertisement interval is 0 */
+            return;
+        }
+
+        if (operationMode == EDDYSTONE_MODE_BEACON) {
+            ble.shutdown();
+            /* Free unused memory */
+            freeBeaconFrames();
+            operationMode = EDDYSTONE_MODE_CONFIG;
+            ble.init(this, &EddystoneService::bleInitComplete);
+            return;
+        }
+
+        operationMode = EDDYSTONE_MODE_CONFIG;
+        setupConfigService();
+    }
+
+    void startBeaconService(uint16_t consecUrlFramesIn = 2, uint16_t consecUidFramesIn = 2, uint16_t consecTlmFramesIn = 2)
+    {
+        if (operationMode == EDDYSTONE_MODE_BEACON) {
+            /* Nothing to do, we are already in beacon mode */
+            return;
+        } else if (!consecUrlFramesIn && !consecUidFramesIn && !consecTlmFramesIn) {
+            /* Nothing to do, the user wants 0 consecutive frames of everything */
+            return;
+        } else if (!beaconPeriod) {
+            /* Nothing to do, the period is 0 for all frames */
+            return;
+        }
+
+        /* Setup tracking of the current advertised frame. Note that this will
+         * cause URL or UID frames to be advertised first!
+         */
+        currentAdvertisedFrame            = EDDYSTONE_FRAME_TLM;
+        consecFrames[EDDYSTONE_FRAME_URL] = consecUrlFramesIn;
+        consecFrames[EDDYSTONE_FRAME_UID] = consecUidFramesIn;
+        consecFrames[EDDYSTONE_FRAME_TLM] = consecTlmFramesIn;
+
+        memset(currentConsecFrames, 0, sizeof(uint16_t) * NUM_EDDYSTONE_FRAMES);
+
+        if (operationMode == EDDYSTONE_MODE_CONFIG) {
+            ble.shutdown();
+            /* Free unused memory */
+            freeConfigCharacteristics();
+            operationMode = EDDYSTONE_MODE_BEACON;
+            ble.init(this, &EddystoneService::bleInitComplete);
+            return;
+        }
+
+        operationMode = EDDYSTONE_MODE_BEACON;
+        setupBeaconService();
+    }
+
+
+    /* It is not the responsibility of the Eddystone implementation to store
+     * the configured parameters in persisten storage since this is
+     * platform-specific. So we provide this function that returns the
+     * configured values that need to be stored and the main application
+     * takes care of storing them.
+     */
+    void getEddystoneParams(EddystoneParams_t *params)
+    {
+        params->lockState     = lockState;
+        params->flags         = flags;
+        params->txPowerMode   = txPowerMode;
+        params->beaconPeriod  = beaconPeriod;
+        params->tlmVersion    = tlmFrame.getTLMVersion();
+        params->urlDataLength = urlFrame.getEncodedURLDataLength();
+
+        memcpy(params->advPowerLevels, advPowerLevels,               sizeof(PowerLevels_t));
+        memcpy(params->lock,           lock,                         sizeof(Lock_t));
+        memcpy(params->unlock,         unlock,                       sizeof(Lock_t));
+        memcpy(params->urlData,        urlFrame.getEncodedURLData(), urlFrame.getEncodedURLDataLength());
+        memcpy(params->uidNamespaceID, uidFrame.getUIDNamespaceID(), sizeof(UIDNamespaceID_t));
+        memcpy(params->uidInstanceID,  uidFrame.getUIDInstanceID(),  sizeof(UIDInstanceID_t));
+    }
+
+private:
+
+    /* When changing modes, we shutdown and init the BLE instance, so
+     * this is needed to complete the initialisation task.
+     */
+    void bleInitComplete(BLE::InitializationCompleteCallbackContext* initContext)
+    {
+        if (initContext->error != BLE_ERROR_NONE) {
+            /* Initialisation failed */
+            return;
+        }
+
+        if (operationMode == EDDYSTONE_MODE_CONFIG) {
+            setupConfigService();
+        } else if (operationMode == EDDYSTONE_MODE_BEACON) {
+            setupBeaconService();
+        } else {
+            /* Some error occurred */
+            return;
+        }
+    }
+
+    void swapAdvertisedFrame(void)
+    {
+        /* This essentially works out which is the next frame to be swapped in
+         * and updated the advertised packets. It will eventually terminate
+         * and in the worst case the frame swapped in is the current advertised
+         * frame.
+         */
+        while (true) {
+            currentAdvertisedFrame = (currentAdvertisedFrame + 1) % NUM_EDDYSTONE_FRAMES;
+
+            if (currentAdvertisedFrame == EDDYSTONE_FRAME_URL && consecFrames[EDDYSTONE_FRAME_URL] > 0) {
+                updateAdvertisementPacket(rawUrlFrame, urlFrame.getRawFrameSize());
+                return;
+            } else if (currentAdvertisedFrame == EDDYSTONE_FRAME_UID && consecFrames[EDDYSTONE_FRAME_UID] > 0) {
+                updateAdvertisementPacket(rawUidFrame, uidFrame.getRawFrameSize());
+                return;
+            } else if (currentAdvertisedFrame == EDDYSTONE_FRAME_TLM && consecFrames[EDDYSTONE_FRAME_UID] > 0) {
+                /* TODO!!!
+                 * This might not be the desired behaviour because essentially the TLM frame will NOT be
+                 * updated while it is advertised! Therefore, if the TLM frame is the ONLY frame being
+                 * advertised it will never be updated.
+                 */
+                if (tlmBeaconTemperatureCallback != NULL) {
+                    tlmFrame.updateBeaconTemperature((*tlmBeaconTemperatureCallback)(tlmFrame.getBeaconTemperature()));
+                }
+                if (tlmBatteryVoltageCallback != NULL) {
+                    tlmFrame.updateBatteryVoltage((*tlmBatteryVoltageCallback)(tlmFrame.getBatteryVoltage()));
+                }
+                tlmFrame.updateTimeSinceBoot(timeSinceBootTimer.read_ms());
+                tlmFrame.constructTLMFrame(rawTlmFrame, *this);
+                updateAdvertisementPacket(rawTlmFrame, tlmFrame.getRawFrameSize());
+                return;
+            }
+        }
+    }
+
+    void updateAdvertisementPacket(uint8_t* rawFrame, size_t rawFrameLength) {
+        ble.gap().clearAdvertisingPayload();
+        ble.gap().setAdvertisingType(GapAdvertisingParams::ADV_NON_CONNECTABLE_UNDIRECTED);
+        ble.gap().setAdvertisingInterval(beaconPeriod);
+        ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED | GapAdvertisingData::LE_GENERAL_DISCOVERABLE);
+        ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LIST_16BIT_SERVICE_IDS, EDDYSTONE_UUID, sizeof(EDDYSTONE_UUID));
+        ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::SERVICE_DATA, rawFrame, rawFrameLength);
+        ble.gap().startAdvertising();
+    }
+
+    void setupBeaconService(void)
+    {
+        /* Initialise arrays to hold constructed raw frames */
+        if (consecFrames[EDDYSTONE_FRAME_URL] > 0) {
+            rawUrlFrame = new uint8_t[urlFrame.getRawFrameSize()];
+            urlFrame.constructURLFrame(rawUrlFrame, *this);
+        }
+
+        if (consecFrames[EDDYSTONE_FRAME_UID] > 0) {
+            rawUidFrame = new uint8_t[uidFrame.getRawFrameSize()];
+            uidFrame.constructUIDFrame(rawUidFrame, *this);
+        }
+
+        if (consecFrames[EDDYSTONE_FRAME_TLM] > 0) {
+            rawTlmFrame = new uint8_t[tlmFrame.getRawFrameSize()];
+            /* Do not initialise because we have to reconstruct every 0.1 secs */
+        }
+
+        /* Configure advertisements */
+        ble.gap().setTxPower(radioPowerLevels[txPowerMode]);
+        swapAdvertisedFrame();
+        ble.gap().onRadioNotification(this, &EddystoneService::radioNotificationCallback);
+    }
+
+    void setupConfigService(void)
+    {
+        lockStateChar      = new ReadOnlyGattCharacteristic<bool>(UUID_LOCK_STATE_CHAR, &lockState);
+        lockChar           = new WriteOnlyArrayGattCharacteristic<uint8_t, sizeof(Lock_t)>(UUID_LOCK_CHAR, lock);
+        unlockChar         = new WriteOnlyArrayGattCharacteristic<uint8_t, sizeof(Lock_t)>(UUID_UNLOCK_CHAR, unlock);
+        urlDataChar        = new GattCharacteristic(UUID_URL_DATA_CHAR, urlFrame.getEncodedURLData(), 0, URL_DATA_MAX, GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_READ | GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_WRITE);
+        flagsChar          = new ReadWriteGattCharacteristic<uint8_t>(UUID_FLAGS_CHAR, &flags);
+        advPowerLevelsChar = new ReadWriteArrayGattCharacteristic<int8_t, sizeof(PowerLevels_t)>(UUID_ADV_POWER_LEVELS_CHAR, advPowerLevels);
+        txPowerModeChar    = new ReadWriteGattCharacteristic<uint8_t>(UUID_TX_POWER_MODE_CHAR, &txPowerMode);
+        beaconPeriodChar   = new ReadWriteGattCharacteristic<uint16_t>(UUID_BEACON_PERIOD_CHAR, &beaconPeriod);
+        resetChar          = new WriteOnlyGattCharacteristic<bool>(UUID_RESET_CHAR, &resetFlag);
+
+        lockChar->setWriteAuthorizationCallback(this, &EddystoneService::lockAuthorizationCallback);
+        unlockChar->setWriteAuthorizationCallback(this, &EddystoneService::unlockAuthorizationCallback);
+        urlDataChar->setWriteAuthorizationCallback(this, &EddystoneService::urlDataWriteAuthorizationCallback);
+        flagsChar->setWriteAuthorizationCallback(this, &EddystoneService::basicAuthorizationCallback<uint8_t>);
+        advPowerLevelsChar->setWriteAuthorizationCallback(this, &EddystoneService::basicAuthorizationCallback<PowerLevels_t>);
+        txPowerModeChar->setWriteAuthorizationCallback(this, &EddystoneService::powerModeAuthorizationCallback);
+        beaconPeriodChar->setWriteAuthorizationCallback(this, &EddystoneService::basicAuthorizationCallback<uint16_t>);
+        resetChar->setWriteAuthorizationCallback(this, &EddystoneService::basicAuthorizationCallback<bool>);
+
+        charTable[0] = lockStateChar;
+        charTable[1] = lockChar;
+        charTable[2] = unlockChar;
+        charTable[3] = urlDataChar;
+        charTable[4] = flagsChar;
+        charTable[5] = advPowerLevelsChar;
+        charTable[6] = txPowerModeChar;
+        charTable[7] = beaconPeriodChar;
+        charTable[8] = resetChar;
+
+        GattService configService(UUID_URL_BEACON_SERVICE, charTable, sizeof(charTable) / sizeof(GattCharacteristic *));
+
+        ble.gattServer().addService(configService);
+        ble.gattServer().onDataWritten(this, &EddystoneService::onDataWrittenCallback);
+        updateCharacteristicValues();
+        setupEddystoneConfigAdvertisements();
+    }
+
+    void freeConfigCharacteristics(void)
+    {
+        delete lockStateChar;
+        delete lockChar;
+        delete unlockChar;
+        delete urlDataChar;
+        delete flagsChar;
+        delete advPowerLevelsChar;
+        delete txPowerModeChar;
+        delete beaconPeriodChar;
+        delete resetChar;
+    }
+
+    void freeBeaconFrames(void)
+    {
+        delete[] rawUrlFrame;
+        delete[] rawUidFrame;
+        delete[] rawTlmFrame;
+    }
+
+    void stopAdvertisingCallback(void)
+    {
+        /* Stop advertisements and defer the frame swap so that it looks like
+         * the advertisement period is consistent
+         */
+        ble.gap().stopAdvertising();
+        stopAdv.attach_us(this, &EddystoneService::swapAdvertisedFrame, beaconPeriod * 1000);
+    }
+
+    void radioNotificationCallback(bool radioActive)
+    {
+        if (radioActive) {
+            /* Do nothing */
+            return;
+        }
+
+        tlmFrame.updatePduCount();
+        currentConsecFrames[currentAdvertisedFrame]++;
+
+        if (consecFrames[currentAdvertisedFrame] > currentConsecFrames[currentAdvertisedFrame]) {
+            return;
+        }
+
+        currentConsecFrames[currentAdvertisedFrame] = 0;
+
+        stopAdv.attach_us(this, &EddystoneService::stopAdvertisingCallback, 1);
+    }
+
+    /*
+     * Internal helper function used to update the GATT database following any
+     * change to the internal state of the service object.
+     */
+    void updateCharacteristicValues(void)
+    {
+        ble.gattServer().write(lockStateChar->getValueHandle(), reinterpret_cast<uint8_t *>(&lockState), sizeof(bool));
+        ble.gattServer().write(urlDataChar->getValueHandle(), urlFrame.getEncodedURLData(), urlFrame.getEncodedURLDataLength());
+        ble.gattServer().write(flagsChar->getValueHandle(), &flags, sizeof(uint8_t));
+        ble.gattServer().write(beaconPeriodChar->getValueHandle(), reinterpret_cast<uint8_t *>(&beaconPeriod), sizeof(uint16_t));
+        ble.gattServer().write(txPowerModeChar->getValueHandle(), &txPowerMode, sizeof(uint8_t));
+        ble.gattServer().write(advPowerLevelsChar->getValueHandle(), reinterpret_cast<uint8_t *>(advPowerLevels), sizeof(PowerLevels_t));
+        ble.gattServer().write(lockChar->getValueHandle(), lock, sizeof(PowerLevels_t));
+        ble.gattServer().write(unlockChar->getValueHandle(), unlock, sizeof(PowerLevels_t));
+    }
+
+    void setupEddystoneConfigAdvertisements(void)
+    {
+        ble.gap().clearAdvertisingPayload();
+        ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED | GapAdvertisingData::LE_GENERAL_DISCOVERABLE);
+
+        /* UUID is in different order in the ADV frame (!) */
+        uint8_t reversedServiceUUID[sizeof(UUID_URL_BEACON_SERVICE)];
+        for (size_t i = 0; i < sizeof(UUID_URL_BEACON_SERVICE); i++) {
+            reversedServiceUUID[i] = UUID_URL_BEACON_SERVICE[sizeof(UUID_URL_BEACON_SERVICE) - i - 1];
+        }
+        ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::COMPLETE_LIST_128BIT_SERVICE_IDS, reversedServiceUUID, sizeof(reversedServiceUUID));
+        ble.gap().accumulateAdvertisingPayload(GapAdvertisingData::GENERIC_TAG);
+        ble.gap().accumulateScanResponse(GapAdvertisingData::COMPLETE_LOCAL_NAME, reinterpret_cast<const uint8_t *>(&DEVICE_NAME), sizeof(DEVICE_NAME));
+        ble.gap().accumulateScanResponse(
+            GapAdvertisingData::TX_POWER_LEVEL,
+            reinterpret_cast<uint8_t *>(&advPowerLevels[EddystoneService::TX_POWER_MODE_LOW]),
+            sizeof(uint8_t));
+
+        ble.gap().setTxPower(radioPowerLevels[txPowerMode]);
+        ble.gap().setDeviceName(reinterpret_cast<const uint8_t *>(&DEVICE_NAME));
+        ble.gap().setAdvertisingType(GapAdvertisingParams::ADV_CONNECTABLE_UNDIRECTED);
+        ble.gap().setAdvertisingInterval(advConfigInterval);
+        ble.gap().startAdvertising();
+    }
+
+    void lockAuthorizationCallback(GattWriteAuthCallbackParams *authParams)
+    {
+        if (lockState) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INSUF_AUTHORIZATION;
+        } else if (authParams->len != sizeof(Lock_t)) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INVALID_ATT_VAL_LENGTH;
+        } else if (authParams->offset != 0) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INVALID_OFFSET;
+        } else {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_SUCCESS;
+        }
+    }
+
+    void unlockAuthorizationCallback(GattWriteAuthCallbackParams *authParams)
+    {
+        if (!lockState && (authParams->len == sizeof(Lock_t))) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_SUCCESS;
+        } else if (authParams->len != sizeof(Lock_t)) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INVALID_ATT_VAL_LENGTH;
+        } else if (authParams->offset != 0) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INVALID_OFFSET;
+        } else if (memcmp(authParams->data, lock, sizeof(Lock_t)) != 0) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INSUF_AUTHORIZATION;
+        } else {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_SUCCESS;
+        }
+    }
+
+    void urlDataWriteAuthorizationCallback(GattWriteAuthCallbackParams *authParams)
+    {
+        if (lockState) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INSUF_AUTHORIZATION;
+        } else if (authParams->offset != 0) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INVALID_OFFSET;
+        } else {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_SUCCESS;
+        }
+    }
+
+    void powerModeAuthorizationCallback(GattWriteAuthCallbackParams *authParams)
+    {
+        if (lockState) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INSUF_AUTHORIZATION;
+        } else if (authParams->len != sizeof(uint8_t)) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INVALID_ATT_VAL_LENGTH;
+        } else if (authParams->offset != 0) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INVALID_OFFSET;
+        } else if (*((uint8_t *)authParams->data) >= NUM_POWER_MODES) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_WRITE_NOT_PERMITTED;
+        } else {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_SUCCESS;
+        }
+    }
+
+    template <typename T>
+    void basicAuthorizationCallback(GattWriteAuthCallbackParams *authParams)
+    {
+        if (lockState) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INSUF_AUTHORIZATION;
+        } else if (authParams->len != sizeof(T)) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INVALID_ATT_VAL_LENGTH;
+        } else if (authParams->offset != 0) {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_ATTERR_INVALID_OFFSET;
+        } else {
+            authParams->authorizationReply = AUTH_CALLBACK_REPLY_SUCCESS;
+        }
+    }
+
+    /*
+     * This callback is invoked when a GATT client attempts to modify any of the
+     * characteristics of this service. Attempts to do so are also applied to
+     * the internal state of this service object.
+     */
+    void onDataWrittenCallback(const GattWriteCallbackParams *writeParams)
+    {
+        uint16_t handle = writeParams->handle;
+
+        if (handle == lockChar->getValueHandle()) {
+            memcpy(lock, writeParams->data, sizeof(Lock_t));
+            /* Set the state to be locked by the lock code (note: zeros are a valid lock) */
+            lockState = true;
+            ble.gattServer().write(lockChar->getValueHandle(), lock, sizeof(PowerLevels_t));
+            ble.gattServer().write(lockStateChar->getValueHandle(), reinterpret_cast<uint8_t *>(&lockState), sizeof(bool));
+        } else if (handle == unlockChar->getValueHandle()) {
+            /* Validated earlier */
+            lockState = false;
+            ble.gattServer().write(unlockChar->getValueHandle(), unlock, sizeof(PowerLevels_t));
+            ble.gattServer().write(lockStateChar->getValueHandle(), reinterpret_cast<uint8_t *>(&lockState), sizeof(bool));
+        } else if (handle == urlDataChar->getValueHandle()) {
+            urlFrame.setEncodedURLData(writeParams->data, writeParams->len);
+            ble.gattServer().write(urlDataChar->getValueHandle(), urlFrame.getEncodedURLData(), urlFrame.getEncodedURLDataLength());
+        } else if (handle == flagsChar->getValueHandle()) {
+            flags = *(writeParams->data);
+            ble.gattServer().write(flagsChar->getValueHandle(), &flags, sizeof(uint8_t));
+        } else if (handle == advPowerLevelsChar->getValueHandle()) {
+            memcpy(advPowerLevels, writeParams->data, sizeof(PowerLevels_t));
+            ble.gattServer().write(advPowerLevelsChar->getValueHandle(), reinterpret_cast<uint8_t *>(advPowerLevels), sizeof(PowerLevels_t));
+        } else if (handle == txPowerModeChar->getValueHandle()) {
+            txPowerMode = *(writeParams->data);
+            ble.gattServer().write(txPowerModeChar->getValueHandle(), &txPowerMode, sizeof(uint8_t));
+        } else if (handle == beaconPeriodChar->getValueHandle()) {
+            uint16_t tmpBeaconPeriod = checkBeaconPeriodBounds(*((uint16_t *)(writeParams->data)));
+            if (tmpBeaconPeriod != beaconPeriod) {
+                beaconPeriod = tmpBeaconPeriod;
+                ble.gattServer().write(beaconPeriodChar->getValueHandle(), reinterpret_cast<uint8_t *>(&beaconPeriod), sizeof(uint16_t));
+            }
+        } else if (handle == resetChar->getValueHandle() && (*((uint8_t *)writeParams->data) != 0)) {
+            /* Reset characteristics to default values */
+            flags        = 0;
+            txPowerMode  = TX_POWER_MODE_LOW;
+            beaconPeriod = DEFAULT_BEACON_PERIOD_MSEC;
+
+            urlFrame.setURLData(DEFAULT_URL);
+            memset(lock, 0, sizeof(Lock_t));
+
+            ble.gattServer().write(urlDataChar->getValueHandle(), urlFrame.getEncodedURLData(), urlFrame.getEncodedURLDataLength());
+            ble.gattServer().write(flagsChar->getValueHandle(), &flags, sizeof(uint8_t));
+            ble.gattServer().write(txPowerModeChar->getValueHandle(), &txPowerMode, sizeof(uint8_t));
+            ble.gattServer().write(beaconPeriodChar->getValueHandle(), reinterpret_cast<uint8_t *>(&beaconPeriod), sizeof(uint16_t));
+            ble.gattServer().write(lockChar->getValueHandle(), lock, sizeof(PowerLevels_t));
+        }
+    }
+
+    uint16_t checkBeaconPeriodBounds(uint16_t beaconPeriodIn) const
+    {
+        /* Re-map beaconPeriod to within permissible bounds if necessary. */
+        if (beaconPeriodIn != 0) {
+            if (beaconPeriodIn < ble.gap().getMinAdvertisingInterval()) {
+                return ble.gap().getMinAdvertisingInterval();
+            } else if (beaconPeriodIn > ble.gap().getMaxAdvertisingInterval()) {
+                return ble.gap().getMaxAdvertisingInterval();
+            }
+        }
+        return beaconPeriodIn;
+    }
+
+    struct TLMFrameFactory
+    {
+    public:
+        TLMFrameFactory(uint8_t  tlmVersionIn           = 0,
+                        uint16_t tlmBatteryVoltageIn    = 0,
+                        uint16_t tlmBeaconTemperatureIn = 0x8000,
+                        uint32_t tlmPduCountIn          = 0,
+                        uint32_t tlmTimeSinceBootIn     = 0) :
+            tlmVersion(tlmVersionIn),
+            lastTimeSinceBootRead(0),
+            tlmBatteryVoltage(tlmBatteryVoltageIn),
+            tlmBeaconTemperature(tlmBeaconTemperatureIn),
+            tlmPduCount(tlmPduCountIn),
+            tlmTimeSinceBoot(tlmTimeSinceBootIn)
+        {
+        }
+
+        void setTLMData(uint8_t tlmVersionIn = 0)
+        {
+            /* According to the Eddystone spec BatteryVoltage is 0 and
+             * BeaconTemperature is 0x8000 if not supported
+             */
+            tlmVersion           = tlmVersionIn;
+            tlmBatteryVoltage    = 0;
+            tlmBeaconTemperature = 0x8000;
+            tlmPduCount          = 0;
+            tlmTimeSinceBoot     = 0;
+        }
+
+        void constructTLMFrame(uint8_t *rawFrame, EddystoneService &eddyService)
+        {
+            (void) eddyService;
+            size_t index = 0;
+            rawFrame[index++] = EDDYSTONE_UUID[0];                    // 16-bit Eddystone UUID
+            rawFrame[index++] = EDDYSTONE_UUID[1];
+            rawFrame[index++] = FRAME_TYPE_TLM;                       // Eddystone frame type = Telemetry
+            rawFrame[index++] = tlmVersion;                           // TLM Version Number
+            rawFrame[index++] = (uint8_t)(tlmBatteryVoltage >> 8);    // Battery Voltage[0]
+            rawFrame[index++] = (uint8_t)(tlmBatteryVoltage >> 0);    // Battery Voltage[1]
+            rawFrame[index++] = (uint8_t)(tlmBeaconTemperature >> 8); // Beacon Temp[0]
+            rawFrame[index++] = (uint8_t)(tlmBeaconTemperature >> 0); // Beacon Temp[1]
+            rawFrame[index++] = (uint8_t)(tlmPduCount >> 24);         // PDU Count [0]
+            rawFrame[index++] = (uint8_t)(tlmPduCount >> 16);         // PDU Count [1]
+            rawFrame[index++] = (uint8_t)(tlmPduCount >> 8);          // PDU Count [2]
+            rawFrame[index++] = (uint8_t)(tlmPduCount >> 0);          // PDU Count [3]
+            rawFrame[index++] = (uint8_t)(tlmTimeSinceBoot >> 24);    // Time Since Boot [0]
+            rawFrame[index++] = (uint8_t)(tlmTimeSinceBoot >> 16);    // Time Since Boot [1]
+            rawFrame[index++] = (uint8_t)(tlmTimeSinceBoot >> 8);     // Time Since Boot [2]
+            rawFrame[index++] = (uint8_t)(tlmTimeSinceBoot >> 0);     // Time Since Boot [3]
+        }
+
+        size_t getRawFrameSize(void) const
+        {
+            return FRAME_SIZE_TLM + EDDYSTONE_UUID_SIZE;
+        }
+
+        void updateTimeSinceBoot(uint32_t nowInMillis)
+        {
+            tlmTimeSinceBoot      += (nowInMillis - lastTimeSinceBootRead) / 100;
+            lastTimeSinceBootRead  = nowInMillis;
+        }
+
+        void updateBatteryVoltage(uint16_t tlmBatteryVoltageIn)
+        {
+            tlmBatteryVoltage = tlmBatteryVoltageIn;
+        }
+
+        void updateBeaconTemperature(uint16_t tlmBeaconTemperatureIn)
+        {
+            tlmBeaconTemperature = tlmBeaconTemperatureIn;
+        }
+
+        void updatePduCount(void)
+        {
+            tlmPduCount++;
+        }
+
+        uint16_t getBatteryVoltage(void) const
+        {
+            return tlmBatteryVoltage;
+        }
+
+        uint16_t getBeaconTemperature(void) const
+        {
+            return tlmBeaconTemperature;
+        }
+
+        uint8_t getTLMVersion(void) const
+        {
+            return tlmVersion;
+        }
+
+    private:
+        static const uint8_t FRAME_TYPE_TLM = 0x20;
+        static const uint8_t FRAME_SIZE_TLM = 14;
+
+        uint8_t              tlmVersion;
+        uint32_t             lastTimeSinceBootRead;
+        uint16_t             tlmBatteryVoltage;
+        uint16_t             tlmBeaconTemperature;
+        uint32_t             tlmPduCount;
+        uint32_t             tlmTimeSinceBoot;
+    };
+
+    class UIDFrameFactory
+    {
+    public:
+        UIDFrameFactory(void)
+        {
+            memset(uidNamespaceID, 0, sizeof(UIDNamespaceID_t));
+            memset(uidInstanceID,  0,  sizeof(UIDInstanceID_t));
+        }
+
+        UIDFrameFactory(const UIDNamespaceID_t uidNamespaceIDIn,
+                        const UIDInstanceID_t  uidInstanceIDIn)
+        {
+            memcpy(uidNamespaceID, uidNamespaceIDIn, sizeof(UIDNamespaceID_t));
+            memcpy(uidInstanceID,  uidInstanceIDIn,  sizeof(UIDInstanceID_t));
+        }
+
+        /* TODO: We could save about 8 bytes if we have uidNamespaceID and uidInstanceID as
+         * const pointers, but this seems a bit of an overkill and might cause problems when
+         * initialising the program using EddystoneParams_t.
+         */
+        void setUIDData(UIDNamespaceID_t *uidNamespaceIDIn, UIDInstanceID_t *uidInstanceIDIn)
+        {
+            memcpy(uidNamespaceID, uidNamespaceIDIn, sizeof(UIDNamespaceID_t));
+            memcpy(uidInstanceID,  uidInstanceIDIn,  sizeof(UIDInstanceID_t));
+        }
+
+        void constructUIDFrame(uint8_t *rawFrame, EddystoneService &eddyService)
+        {
+            size_t index = 0;
+
+            rawFrame[index++] = EDDYSTONE_UUID[0];                                   // 16-bit Eddystone UUID
+            rawFrame[index++] = EDDYSTONE_UUID[1];
+            rawFrame[index++] = FRAME_TYPE_UID;                                      // 1B  Type
+            rawFrame[index++] = eddyService.advPowerLevels[eddyService.txPowerMode]; // 1B  Power @ 0meter
+
+            memcpy(rawFrame + index, uidNamespaceID, sizeof(UIDNamespaceID_t));      // 10B Namespace ID
+            index += sizeof(UIDNamespaceID_t);
+            memcpy(rawFrame + index, uidInstanceID, sizeof(UIDInstanceID_t));        // 6B Instance ID
+            index += sizeof(UIDInstanceID_t);
+
+            memset(rawFrame + index, 0, 2 * sizeof(uint8_t));                        // 2B RFU, which are unused
+        }
+
+        size_t getRawFrameSize(void) const
+        {
+            return FRAME_SIZE_UID + EDDYSTONE_UUID_SIZE;
+        }
+
+        uint8_t* getUIDNamespaceID(void)
+        {
+            return uidNamespaceID;
+        }
+
+        uint8_t* getUIDInstanceID(void)
+        {
+            return uidInstanceID;
+        }
+
+    private:
+        static const uint8_t FRAME_TYPE_UID = 0x00;
+        static const uint8_t FRAME_SIZE_UID = 20;
+
+        UIDNamespaceID_t     uidNamespaceID;
+        UIDInstanceID_t      uidInstanceID;
+    };
+
+    struct URLFrameFactory
+    {
+    public:
+        URLFrameFactory(void)
+        {
+            urlDataLength = 0;
+            memset(urlData, 0, sizeof(UrlData_t));
+        }
+
+        URLFrameFactory(const char *urlDataIn)
+        {
+            encodeURL(urlDataIn);
+        }
+
+        URLFrameFactory(UrlData_t urlDataIn, uint8_t urlDataLength)
+        {
+            if (urlDataLength > URL_DATA_MAX) {
+                memcpy(urlData, urlDataIn, URL_DATA_MAX);
+            } else {
+                memcpy(urlData, urlDataIn, urlDataLength);
+            }
+        }
+
+        void constructURLFrame(uint8_t* rawFrame, EddystoneService eddyService)
+        {
+            size_t index = 0;
+            rawFrame[index++] = EDDYSTONE_UUID[0];                                   // 16-bit Eddystone UUID
+            rawFrame[index++] = EDDYSTONE_UUID[1];
+            rawFrame[index++] = FRAME_TYPE_URL;                                      // 1B  Type
+            rawFrame[index++] = eddyService.advPowerLevels[eddyService.txPowerMode]; // 1B  Power @ 0meter
+            memcpy(rawFrame + index, urlData, urlDataLength);                        // Encoded URL
+        }
+
+        size_t getRawFrameSize(void) const
+        {
+            return urlDataLength + FRAME_MIN_SIZE_URL + EDDYSTONE_UUID_SIZE;
+        }
+
+        uint8_t* getEncodedURLData(void)
+        {
+            return urlData;
+        }
+
+        uint8_t getEncodedURLDataLength(void) const
+        {
+            return urlDataLength;
+        }
+
+        void setURLData(const char *urlDataIn)
+        {
+            encodeURL(urlDataIn);
+        }
+
+        void setEncodedURLData(const uint8_t* urlEncodedDataIn, const uint8_t urlEncodedDataLengthIn)
+        {
+            urlDataLength = urlEncodedDataLengthIn;
+            memcpy(urlData, urlEncodedDataIn, urlEncodedDataLengthIn);
+        }
+
+    private:
+        static const uint8_t FRAME_TYPE_URL     = 0x10;
+        /* Even if the URL is 0 bytes we still need to include the type and txPower i.e. 2 bytes */
+        static const uint8_t FRAME_MIN_SIZE_URL = 2;
+
+        uint8_t              urlDataLength;
+        UrlData_t            urlData;
+
+        void encodeURL(const char *urlDataIn)
+        {
+            const char  *prefixes[] = {
+                "http://www.",
+                "https://www.",
+                "http://",
+                "https://",
+            };
+            const size_t NUM_PREFIXES = sizeof(prefixes) / sizeof(char *);
+            const char  *suffixes[]   = {
+                ".com/",
+                ".org/",
+                ".edu/",
+                ".net/",
+                ".info/",
+                ".biz/",
+                ".gov/",
+                ".com",
+                ".org",
+                ".edu",
+                ".net",
+                ".info",
+                ".biz",
+                ".gov"
+            };
+            const size_t NUM_SUFFIXES = sizeof(suffixes) / sizeof(char *);
+
+            urlDataLength = 0;
+            memset(urlData, 0, sizeof(UrlData_t));
+
+            if ((urlDataIn == NULL) || (strlen(urlDataIn) == 0)) {
+                return;
+            }
+
+            /*
+             * handle prefix
+             */
+            for (size_t i = 0; i < NUM_PREFIXES; i++) {
+                size_t prefixLen = strlen(prefixes[i]);
+                if (strncmp(urlDataIn, prefixes[i], prefixLen) == 0) {
+                    urlData[urlDataLength++]  = i;
+                    urlDataIn                      += prefixLen;
+                    break;
+                }
+            }
+
+            /*
+             * handle suffixes
+             */
+            while (*urlDataIn && (urlDataLength < URL_DATA_MAX)) {
+                /* check for suffix match */
+                size_t i;
+                for (i = 0; i < NUM_SUFFIXES; i++) {
+                    size_t suffixLen = strlen(suffixes[i]);
+                    if (strncmp(urlDataIn, suffixes[i], suffixLen) == 0) {
+                        urlData[urlDataLength++]  = i;
+                        urlDataIn                      += suffixLen;
+                        break; /* from the for loop for checking against suffixes */
+                    }
+                }
+                /* This is the default case where we've got an ordinary character which doesn't match a suffix. */
+                if (i == NUM_SUFFIXES) {
+                    urlData[urlDataLength++] = *urlDataIn;
+                    ++urlDataIn;
+                }
+            }
+        }
+    };
+
+    BLE                                                             &ble;
+    uint32_t                                                        advConfigInterval;
+    uint8_t                                                         operationMode;
+
+    URLFrameFactory                                                 urlFrame;
+    UIDFrameFactory                                                 uidFrame;
+    TLMFrameFactory                                                 tlmFrame;
+
+    PowerLevels_t                                                   radioPowerLevels;
+    PowerLevels_t                                                   advPowerLevels;
+    bool                                                            lockState;
+    bool                                                            resetFlag;
+    Lock_t                                                          lock;
+    Lock_t                                                          unlock;
+    uint8_t                                                         flags;
+    uint8_t                                                         txPowerMode;
+    uint16_t                                                        beaconPeriod;
+
+    ReadOnlyGattCharacteristic<bool>                                *lockStateChar;
+    WriteOnlyArrayGattCharacteristic<uint8_t, sizeof(Lock_t)>       *lockChar;
+    WriteOnlyArrayGattCharacteristic<uint8_t, sizeof(Lock_t)>       *unlockChar;
+    GattCharacteristic                                              *urlDataChar;
+    ReadWriteGattCharacteristic<uint8_t>                            *flagsChar;
+    ReadWriteArrayGattCharacteristic<int8_t, sizeof(PowerLevels_t)> *advPowerLevelsChar;
+    ReadWriteGattCharacteristic<uint8_t>                            *txPowerModeChar;
+    ReadWriteGattCharacteristic<uint16_t>                           *beaconPeriodChar;
+    WriteOnlyGattCharacteristic<bool>                               *resetChar;
+
+    uint8_t                                                         *rawUrlFrame;
+    uint8_t                                                         *rawUidFrame;
+    uint8_t                                                         *rawTlmFrame;
+
+    uint16_t                                                        consecFrames[NUM_EDDYSTONE_FRAMES];
+    uint16_t                                                        currentConsecFrames[NUM_EDDYSTONE_FRAMES];
+    uint8_t                                                         currentAdvertisedFrame;
+
+    TlmUpdateCallback_t                                             tlmBatteryVoltageCallback;
+    TlmUpdateCallback_t                                             tlmBeaconTemperatureCallback;
+
+    Timer                                                           timeSinceBootTimer;
+    /* TODO: Modify this to use minar scheduler. */
+    Timeout                                                         stopAdv;
+
+    GattCharacteristic                                              *charTable[TOTAL_CHARACTERISTICS];
+};
+
+#endif  // SERVICES_EDDYSTONEBEACON_H_

--- a/BLE_EddystoneServiceExperimental/source/main.cpp
+++ b/BLE_EddystoneServiceExperimental/source/main.cpp
@@ -88,13 +88,13 @@ static void bleInitComplete(BLE::InitializationCompleteCallbackContext* initCont
     bool fetchedFromPersistentStorage = loadURIBeaconConfigParams(&eddyParams);
 
     /* Set UID and TLM frame data */
-    EddystoneService::UIDNamespaceID_t uidNamespaceID = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
-    EddystoneService::UIDInstanceID_t  uidInstanceID = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    const EddystoneService::UIDNamespaceID_t uidNamespaceID = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
+    const EddystoneService::UIDInstanceID_t  uidInstanceID = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
     uint8_t tlmVersion = 0x00;
 
     /* Initialize a EddystoneBeaconConfig service providing config params, default URI, and power levels. */
-    static EddystoneService::PowerLevels_t defaultAdvPowerLevels = {-47, -33, -21, -13}; // Values for ADV packets related to firmware levels, calibrated based on measured values at 1m
-    static EddystoneService::PowerLevels_t radioPowerLevels      = {-30, -16, -4, 4};    // Values for radio power levels, provided by manufacturer.
+    static const EddystoneService::PowerLevels_t defaultAdvPowerLevels = {-47, -33, -21, -13}; // Values for ADV packets related to firmware levels, calibrated based on measured values at 1m
+    static const EddystoneService::PowerLevels_t radioPowerLevels      = {-30, -16, -4, 4};    // Values for radio power levels, provided by manufacturer.
 
     if (fetchedFromPersistentStorage) {
         eddyServicePtr = new EddystoneService(ble, eddyParams, defaultAdvPowerLevels, radioPowerLevels, 500);

--- a/BLE_EddystoneServiceExperimental/source/main.cpp
+++ b/BLE_EddystoneServiceExperimental/source/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "mbed.h"
+#include "mbed-drivers/mbed.h"
 #include "ble/BLE.h"
 #include "EddystoneService.h"
 #include "ConfigParamsPersistence.h"
@@ -67,12 +67,14 @@ static void onBleInitError(BLE::InitializationCompleteCallbackContext* initConte
 
 static void bleInitComplete(BLE::InitializationCompleteCallbackContext* initContext)
 {
-    if (initContext->error != BLE_ERROR_NONE) {
+    BLE         &ble  = initContext->ble;
+    ble_error_t error = initContext->error;
+
+    if (error != BLE_ERROR_NONE) {
         onBleInitError(initContext);
         return;
     }
 
-    BLE &ble = initContext->ble;
     ble.gap().onDisconnection(disconnectionCallback);
 
     /*

--- a/BLE_EddystoneServiceExperimental/source/main.cpp
+++ b/BLE_EddystoneServiceExperimental/source/main.cpp
@@ -1,0 +1,125 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+#include "ble/BLE.h"
+#include "EddystoneService.h"
+#include "ConfigParamsPersistence.h"
+
+BLE ble;
+EddystoneService *eddyServicePtr;
+
+/* Duration after power-on that config service is available. */
+static const int CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS = 30;
+
+DigitalOut led(LED1, 1);
+
+/**
+ * Callback triggered upon a disconnection event.
+ */
+static void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *cbParams)
+{
+    (void) cbParams;
+    ble.gap().startAdvertising();
+}
+
+/**
+ * Callback triggered some time after application started to switch to beacon mode.
+ */
+static void timeout(void)
+{
+    Gap::GapState_t state;
+    state = ble.getGapState();
+    if (!state.connected) { /* don't switch if we're in a connected state. */
+        EddystoneService::EddystoneParams_t eddyParams;
+        eddyServicePtr->startBeaconService(5, 5, 5);
+        /* Write params to persistent storage */
+        eddyServicePtr->getEddystoneParams(&eddyParams);
+        saveURIBeaconConfigParams(&eddyParams);
+    } else {
+        minar::Scheduler::postCallback(timeout).delay(minar::milliseconds(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000));
+    }
+}
+
+static void blinky(void)
+{
+    led = !led;
+}
+
+static void onBleInitError(BLE::InitializationCompleteCallbackContext* initContext)
+{
+    /* Initialization error handling goes here... */
+    (void) initContext;
+}
+
+static void bleInitComplete(BLE::InitializationCompleteCallbackContext* initContext)
+{
+    if (initContext->error != BLE_ERROR_NONE) {
+        onBleInitError(initContext);
+        return;
+    }
+
+    BLE &ble = initContext->ble;
+    ble.gap().onDisconnection(disconnectionCallback);
+
+    /*
+     * Load parameters from (platform specific) persistent storage. Parameters
+     * can be set to non-default values while the URIBeacon is in configuration
+     * mode (within the first 60 seconds of power-up). Thereafter, parameters
+     * get copied out to persistent storage before switching to normal URIBeacon
+     * operation.
+     */
+    EddystoneService::EddystoneParams_t eddyParams;
+    bool fetchedFromPersistentStorage = loadURIBeaconConfigParams(&eddyParams);
+
+    /* Set UID and TLM frame data */
+    EddystoneService::UIDNamespaceID_t uidNamespaceID = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
+    EddystoneService::UIDInstanceID_t  uidInstanceID = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+    uint8_t tlmVersion = 0x00;
+
+    /* Initialize a EddystoneBeaconConfig service providing config params, default URI, and power levels. */
+    static EddystoneService::PowerLevels_t defaultAdvPowerLevels = {-47, -33, -21, -13}; // Values for ADV packets related to firmware levels, calibrated based on measured values at 1m
+    static EddystoneService::PowerLevels_t radioPowerLevels      = {-30, -16, -4, 4};    // Values for radio power levels, provided by manufacturer.
+
+    if (fetchedFromPersistentStorage) {
+        eddyServicePtr = new EddystoneService(ble, eddyParams, defaultAdvPowerLevels, radioPowerLevels, 500);
+    } else {
+        /* Set everything to defaults */
+        eddyServicePtr = new EddystoneService(ble, defaultAdvPowerLevels, radioPowerLevels, 500);
+
+        /* Set default URL, UID and TLM frame data if not initialized through the config service */
+        eddyServicePtr->setURLData("http://mbed.org");
+        eddyServicePtr->setUIDData(&uidNamespaceID, &uidInstanceID);
+        eddyServicePtr->setTLMData(tlmVersion);
+    }
+
+    /* Start Eddystone in config mode */
+    eddyServicePtr->startConfigService();
+
+    minar::Scheduler::postCallback(timeout).delay(minar::milliseconds(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000));
+}
+
+void app_start(int, char *[])
+{
+    /* Tell standard C library to not allocate large buffers for these streams */
+    setbuf(stdout, NULL);
+    setbuf(stderr, NULL);
+    setbuf(stdin, NULL);
+
+    minar::Scheduler::postCallback(blinky).period(minar::milliseconds(500));
+
+    ble.init(bleInitComplete);
+}

--- a/BLE_EddystoneServiceExperimental/source/nrfConfigParamsPersistence.cpp
+++ b/BLE_EddystoneServiceExperimental/source/nrfConfigParamsPersistence.cpp
@@ -1,0 +1,114 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "pstorage.h"
+#include "nrf_error.h"
+#include "ConfigParamsPersistence.h"
+
+/**
+ * Nordic specific structure used to store params persistently.
+ * It extends EddystoneConfigService::Params_t with a persistence signature.
+ */
+struct PersistentParams_t {
+    EddystoneService::EddystoneParams_t params;
+    uint32_t                         persistenceSignature; /* This isn't really a parameter, but having the expected
+                                                            * magic value in this field indicates persistence. */
+
+    static const uint32_t MAGIC = 0x1BEAC000;              /* Magic that identifies persistence */
+};
+
+/**
+ * The following is a module-local variable to hold configuration parameters for
+ * short periods during flash access. This is necessary because the pstorage
+ * APIs don't copy in the memory provided as data source. The memory cannot be
+ * freed or reused by the application until this flash access is complete. The
+ * load and store operations in this module initialize persistentParams and then
+ * pass it on to the 'pstorage' APIs.
+ */
+uint32_t persistenceSignature;
+
+
+static pstorage_handle_t pstorageHandle;
+
+/**
+ * Dummy callback handler needed by Nordic's pstorage module. This is called
+ * after every flash access.
+ */
+static void pstorageNotificationCallback(pstorage_handle_t *p_handle,
+                                         uint8_t            op_code,
+                                         uint32_t           result,
+                                         uint8_t           *p_data,
+                                         uint32_t           data_len)
+{
+    (void) p_handle;
+    (void) op_code;
+    (void) result;
+    (void) p_data;
+    (void) data_len;
+    /* APP_ERROR_CHECK(result); */
+}
+
+/* Platform-specific implementation for persistence on the nRF5x. Based on the
+ * pstorage module provided by the Nordic SDK. */
+bool loadURIBeaconConfigParams(EddystoneService::EddystoneParams_t *paramsP)
+{
+    static bool pstorageInitied = false;
+    if (!pstorageInitied) {
+        pstorage_init();
+
+        static pstorage_module_param_t pstorageParams = {
+            .cb          = pstorageNotificationCallback,
+            .block_size  = sizeof(PersistentParams_t),
+            .block_count = 1
+        };
+        pstorage_register(&pstorageParams, &pstorageHandle);
+        pstorageInitied = true;
+    }
+
+    PersistentParams_t persistentParams;
+    if ((pstorage_load(reinterpret_cast<uint8_t *>(&persistentParams), &pstorageHandle, sizeof(PersistentParams_t), 0) != NRF_SUCCESS) ||
+        (persistentParams.persistenceSignature != PersistentParams_t::MAGIC)) {
+        // On failure zero out and let the service reset to defaults
+        memset(paramsP, 0, sizeof(EddystoneService::EddystoneParams_t));
+        return false;
+    }
+
+    memcpy(paramsP, &persistentParams.params, sizeof(EddystoneService::EddystoneParams_t));
+    persistenceSignature = persistentParams.persistenceSignature;
+    return true;
+}
+
+/* Platform-specific implementation for persistence on the nRF5x. Based on the
+ * pstorage module provided by the Nordic SDK. */
+void saveURIBeaconConfigParams(const EddystoneService::EddystoneParams_t *paramsP)
+{
+    PersistentParams_t persistentParams;
+    memcpy(&persistentParams.params, paramsP, sizeof(EddystoneService::EddystoneParams_t));
+    if (persistenceSignature != PersistentParams_t::MAGIC) {
+        persistentParams.persistenceSignature = PersistentParams_t::MAGIC;
+        persistenceSignature = PersistentParams_t::MAGIC;
+        pstorage_store(&pstorageHandle,
+                       reinterpret_cast<uint8_t *>(&persistentParams),
+                       sizeof(PersistentParams_t),
+                       0 /* offset */);
+    } else {
+        persistentParams.persistenceSignature = PersistentParams_t::MAGIC;
+        pstorage_update(&pstorageHandle,
+                        reinterpret_cast<uint8_t *>(&persistentParams),
+                        sizeof(PersistentParams_t),
+                        0 /* offset */);
+    }
+}


### PR DESCRIPTION
Develop experimental example of a new EddystoneService implementation that will eventually replace both EddystoneConfigService and EddystoneService from BLE API in the future. The new implementation is expected to more efficient in terms of memory and have better structured code.