### PR TITLE
Fix BLE_Beacon demo and modify readme

### DIFF
--- a/BLE_Beacon/source/main.cpp
+++ b/BLE_Beacon/source/main.cpp
@@ -56,7 +56,7 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
      * Note: please remember to calibrate your beacons TX Power for more accurate results.
      */
     static const uint8_t uuid[] = {0xE2, 0x0A, 0x39, 0xF4, 0x73, 0xF5, 0x4B, 0xC4,
-                            0xA1, 0x2F, 0x17, 0xD1, 0xAD, 0x07, 0xA9, 0x61};
+                                   0xA1, 0x2F, 0x17, 0xD1, 0xAD, 0x07, 0xA9, 0x61};
     uint16_t majorNumber = 1122;
     uint16_t minorNumber = 3344;
     uint16_t txPower     = 0xC8;

--- a/BLE_Beacon/source/main.cpp
+++ b/BLE_Beacon/source/main.cpp
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-#include "mbed.h"
+#include "mbed-drivers/mbed.h"
 #include "ble/BLE.h"
 #include "ble/services/iBeacon.h"
 
-BLE ble;
+static iBeacon* ibeaconPtr;
 
 /**
  * This function is called when the ble initialization process has failled
  */
 void onBleInitError(BLE &ble, ble_error_t error)
 {
-    // Initialization error handling should go here
+    /* Initialization error handling should go here */
 }
 
 /**
@@ -37,12 +37,12 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
     ble_error_t error = params->error;
 
     if (error != BLE_ERROR_NONE) {
-        // in case of error, forward the error handling to onBleInitError
+        /* In case of error, forward the error handling to onBleInitError */
         onBleInitError(ble, error);
         return;
     }
 
-    // ensure that it is the default instance of BLE
+    /* Ensure that it is the default instance of BLE */
     if(ble.getInstanceID() != BLE::DEFAULT_INSTANCE) {
         return;
     }
@@ -55,18 +55,19 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
      *
      * Note: please remember to calibrate your beacons TX Power for more accurate results.
      */
-    const uint8_t uuid[] = {0xE2, 0x0A, 0x39, 0xF4, 0x73, 0xF5, 0x4B, 0xC4,
+    static const uint8_t uuid[] = {0xE2, 0x0A, 0x39, 0xF4, 0x73, 0xF5, 0x4B, 0xC4,
                             0xA1, 0x2F, 0x17, 0xD1, 0xAD, 0x07, 0xA9, 0x61};
     uint16_t majorNumber = 1122;
     uint16_t minorNumber = 3344;
     uint16_t txPower     = 0xC8;
-    iBeacon ibeacon(ble, uuid, majorNumber, minorNumber, txPower);
+    ibeaconPtr = new iBeacon(ble, uuid, majorNumber, minorNumber, txPower);
 
     ble.gap().setAdvertisingInterval(1000); /* 1000ms. */
     ble.gap().startAdvertising();
 }
 
-void app_start(int argc, char *argv[])
+void app_start(int, char**)
 {
+    BLE &ble = BLE::Instance();
     ble.init(bleInitComplete);
 }

--- a/BLE_EddystoneService/module.json
+++ b/BLE_EddystoneService/module.json
@@ -1,5 +1,5 @@
 {
-  "name": "ble-eddystonebeaconexperimental",
+  "name": "ble-eddystoneservice",
   "version": "0.0.1",
   "description": "This example demonstrates how to set up and initialize a Eddystone Beacon.",
   "licenses": [

--- a/BLE_EddystoneService/readme.md
+++ b/BLE_EddystoneService/readme.md
@@ -53,6 +53,11 @@ and reset the device.
 If your target has very tight memory constraints, you can modify the `config.json`
 to suit your needs. For instance, by changing the SoftDevice from S130 to S110.
 
+*NOTE:* This demo is known to fail if you are building the application for nRF51-based
+16K targets using the SoftDevice 130 (S130). This is because the program runs out of memory.
+To fix this problem, before you build the software open the `config.json` and change the
+“softdevice” to “S110”.
+
 Checking for Success
 ====================
 


### PR DESCRIPTION
Modify the BLE_Beacon demo to allocate the iBeacon object in heap rather than in the stack where it is lost after the function terminates. Also, modified BLE_EddystoneService readme file to include instructions on switching SoftDevice when building for 16K targets. Finally changes the module name of the BLE_EddystoneService in the module.json file. @rgrover