### PR TITLE
Fix macros for compatibility with mbed classic

### DIFF
--- a/BLE_EddystoneService/source/EddystoneService.cpp
+++ b/BLE_EddystoneService/source/EddystoneService.cpp
@@ -387,7 +387,7 @@ void EddystoneService::radioNotificationCallback(bool radioActive)
 #ifdef YOTTA_CFG_MBED_OS
     minar::Scheduler::postCallback(this, &EddystoneService::swapAdvertisedFrame);
 #else
-    swapAdvertisedFrameTimeout.attach_us(this, &EddystoneService::swapAdvertisedFrame);
+    swapAdvertisedFrameTimeout.attach_us(this, &EddystoneService::swapAdvertisedFrame, 1);
 #endif
 }
 

--- a/BLE_EddystoneService/source/EddystoneService.h
+++ b/BLE_EddystoneService/source/EddystoneService.h
@@ -228,7 +228,7 @@ private:
     TlmUpdateCallback_t                                             tlmBeaconTemperatureCallback;
 
     Timer                                                           timeSinceBootTimer;
-#ifdef YOTTA_CFG_MBED_OS
+#ifndef YOTTA_CFG_MBED_OS
     Timeout                                                         swapAdvertisedFrameTimeout;
 #endif
 

--- a/BLE_EddystoneService/source/EddystoneTypes.h
+++ b/BLE_EddystoneService/source/EddystoneTypes.h
@@ -1,4 +1,3 @@
-
 /* mbed Microcontroller Library
  * Copyright (c) 2006-2015 ARM Limited
  *

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -18,7 +18,6 @@
 #include "ble/BLE.h"
 #include "EddystoneService.h"
 
-BLE ble;
 EddystoneService *eddyServicePtr;
 
 /* Duration after power-on that config service is available. */
@@ -32,7 +31,7 @@ DigitalOut led(LED1, 1);
 static void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *cbParams)
 {
     (void) cbParams;
-    ble.gap().startAdvertising();
+    BLE::Instance().startAdvertising();
 }
 
 /**
@@ -41,7 +40,7 @@ static void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *cbPa
 static void timeout(void)
 {
     Gap::GapState_t state;
-    state = ble.getGapState();
+    state = BLE::Instance().getGapState();
     if (!state.connected) { /* don't switch if we're in a connected state. */
         eddyServicePtr->startBeaconService(5, 5, 5);
     } else {
@@ -104,5 +103,6 @@ void app_start(int, char *[])
 
     minar::Scheduler::postCallback(blinky).period(minar::milliseconds(500));
 
+    BLE &ble = BLE::Instance();
     ble.init(bleInitComplete);
 }

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -31,7 +31,7 @@ DigitalOut led(LED1, 1);
 static void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *cbParams)
 {
     (void) cbParams;
-    BLE::Instance().startAdvertising();
+    BLE::Instance().gap().startAdvertising();
 }
 
 /**
@@ -40,7 +40,7 @@ static void disconnectionCallback(const Gap::DisconnectionCallbackParams_t *cbPa
 static void timeout(void)
 {
     Gap::GapState_t state;
-    state = BLE::Instance().getGapState();
+    state = BLE::Instance().gap().getState();
     if (!state.connected) { /* don't switch if we're in a connected state. */
         eddyServicePtr->startBeaconService(5, 5, 5);
     } else {


### PR DESCRIPTION
Fix wrong preprocessor directive that was causing a ticker to be defined when not needed. Also, fix the call to attach_us of the Timeout that would cause a build error in mbed classic. Finally, the main.cpp code is change to not define a global BLE object, but call BLE::Instance() rather.