### PR TITLE
BLE_URLBeacon: Use extern c to import nordic sdk files written in c

### DIFF
--- a/BLE_URIBeacon/source/nrfConfigParamsPersistence.cpp
+++ b/BLE_URIBeacon/source/nrfConfigParamsPersistence.cpp
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+extern "C" {
 #include "pstorage.h"
+}
+
 #include "nrf_error.h"
 #include "ConfigParamsPersistence.h"
 


### PR DESCRIPTION
This is to prevent examples being broken in the pending update to ble-nrf51822.

