### PR TITLE
	Add persistent storage support to Eddystone demo

### DIFF
--- a/BLE_EddystoneService/source/URLFrame.cpp
+++ b/BLE_EddystoneService/source/URLFrame.cpp
@@ -27,13 +27,10 @@ URLFrame::URLFrame(const char *urlDataIn)
     encodeURL(urlDataIn);
 }
 
-URLFrame::URLFrame(UrlData_t urlDataIn, uint8_t urlDataLength)
+URLFrame::URLFrame(UrlData_t urlDataIn, uint8_t urlDataLengthIn)
 {
-    if (urlDataLength > URL_DATA_MAX) {
-        memcpy(urlData, urlDataIn, URL_DATA_MAX);
-    } else {
-        memcpy(urlData, urlDataIn, urlDataLength);
-    }
+    urlDataLength = (urlDataLengthIn > URL_DATA_MAX) ? URL_DATA_MAX : urlDataLengthIn;
+    memcpy(urlData, urlDataIn, urlDataLength);
 }
 
 void URLFrame::constructURLFrame(uint8_t* rawFrame, int8_t advPowerLevel)

--- a/BLE_EddystoneService/source/URLFrame.h
+++ b/BLE_EddystoneService/source/URLFrame.h
@@ -27,7 +27,7 @@ public:
 
     URLFrame(const char *urlDataIn);
 
-    URLFrame(UrlData_t urlDataIn, uint8_t urlDataLength);
+    URLFrame(UrlData_t urlDataIn, uint8_t urlDataLengthIn);
 
     void constructURLFrame(uint8_t* rawFrame, int8_t advPowerLevel);
 

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -18,10 +18,32 @@
 #include "ble/BLE.h"
 #include "EddystoneService.h"
 
+#ifdef TARGET_NRF51822
+    #include "nrfPersistentStorageHelper/ConfigParamsPersistence.h"
+#endif
+
 EddystoneService *eddyServicePtr;
 
 /* Duration after power-on that config service is available. */
 static const int CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS = 30;
+
+/* Default UID frame data */
+static const UIDNamespaceID_t uidNamespaceID = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
+static const UIDInstanceID_t  uidInstanceID  = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
+
+/* Default version in TLM frame */
+static const uint8_t tlmVersion = 0x00;
+
+/* Default configuration advertising interval */
+static const uint32_t advConfigInterval = 500;
+
+/* Default URL */
+static const char defaultUrl[] = "http://mbed.org";
+
+/* Values for ADV packets related to firmware levels, calibrated based on measured values at 1m */
+static const PowerLevels_t defaultAdvPowerLevels = {-47, -33, -21, -13};
+/* Values for radio power levels, provided by manufacturer. */
+static const PowerLevels_t radioPowerLevels      = {-30, -16, -4, 4};
 
 DigitalOut led(LED1, 1);
 
@@ -43,6 +65,11 @@ static void timeout(void)
     state = BLE::Instance().gap().getState();
     if (!state.connected) { /* don't switch if we're in a connected state. */
         eddyServicePtr->startBeaconService(5, 5, 5);
+#ifdef TARGET_NRF51822
+        EddystoneService::EddystoneParams_t params;
+        eddyServicePtr->getEddystoneParams(&params);
+        saveEddystoneServiceConfigParams(&params);
+#endif
     } else {
         minar::Scheduler::postCallback(timeout).delay(minar::milliseconds(CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS * 1000));
     }
@@ -59,6 +86,17 @@ static void onBleInitError(BLE::InitializationCompleteCallbackContext* initConte
     (void) initContext;
 }
 
+static void initializeEddystoneToDefaults(BLE &ble)
+{
+    /* Set everything to defaults */
+    eddyServicePtr = new EddystoneService(ble, defaultAdvPowerLevels, radioPowerLevels, advConfigInterval);
+
+    /* Set default URL, UID and TLM frame data if not initialized through the config service */
+    eddyServicePtr->setURLData(defaultUrl);
+    eddyServicePtr->setUIDData(uidNamespaceID, uidInstanceID);
+    eddyServicePtr->setTLMData(tlmVersion);
+}
+
 static void bleInitComplete(BLE::InitializationCompleteCallbackContext* initContext)
 {
     BLE         &ble  = initContext->ble;
@@ -71,22 +109,16 @@ static void bleInitComplete(BLE::InitializationCompleteCallbackContext* initCont
 
     ble.gap().onDisconnection(disconnectionCallback);
 
-    /* Set UID and TLM frame data */
-    const UIDNamespaceID_t uidNamespaceID = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
-    const UIDInstanceID_t  uidInstanceID  = {0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF};
-    uint8_t tlmVersion = 0x00;
-
-    /* Initialize a EddystoneBeaconConfig service providing config params, default URI, and power levels. */
-    static const PowerLevels_t defaultAdvPowerLevels = {-47, -33, -21, -13}; // Values for ADV packets related to firmware levels, calibrated based on measured values at 1m
-    static const PowerLevels_t radioPowerLevels      = {-30, -16, -4, 4};    // Values for radio power levels, provided by manufacturer.
-
-    /* Set everything to defaults */
-    eddyServicePtr = new EddystoneService(ble, defaultAdvPowerLevels, radioPowerLevels, 500);
-
-    /* Set default URL, UID and TLM frame data if not initialized through the config service */
-    eddyServicePtr->setURLData("http://mbed.org");
-    eddyServicePtr->setUIDData(uidNamespaceID, uidInstanceID);
-    eddyServicePtr->setTLMData(tlmVersion);
+#ifdef TARGET_NRF51822
+    EddystoneService::EddystoneParams_t params;
+    if (loadEddystoneServiceConfigParams(&params)) {
+        eddyServicePtr = new EddystoneService(ble, params, defaultAdvPowerLevels, radioPowerLevels, advConfigInterval);
+    } else {
+        initializeEddystoneToDefaults(ble);
+    }
+#else
+    initializeEddystoneToDefaults(ble);
+#endif
 
     /* Start Eddystone in config mode */
     eddyServicePtr->startConfigService();

--- a/BLE_EddystoneService/source/nrfPersistentStorageHelper/ConfigParamsPersistence.h
+++ b/BLE_EddystoneService/source/nrfPersistentStorageHelper/ConfigParamsPersistence.h
@@ -1,0 +1,57 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef TARGET_NRF51822 /* Persistent storage supported on nrf51 platforms */
+
+#ifndef __BLE_CONFIG_PARAMS_PERSISTENCE_H__
+#define __BLE_CONFIG_PARAMS_PERSISTENCE_H__
+
+#include "../EddystoneService.h"
+
+/**
+ * Generic API to load the Eddystone Service configuration parameters from persistent
+ * storage. If persistent storage isn't available, the persistenceSignature
+ * member of params may be left un-initialized to the MAGIC, and this will cause
+ * a reset to default values.
+ *
+ * @param[out] paramsP
+ *                 The parameters to be filled in from persistence storage. This
+                   argument can be NULL if the caller is only interested in
+                   discovering the persistence status of params.
+
+ * @return true if params were loaded from persistent storage and have usefully
+ *         initialized fields.
+ */
+bool loadEddystoneServiceConfigParams(EddystoneService::EddystoneParams_t *paramsP);
+
+/**
+ * Generic API to store the Eddystone Service configuration parameters to persistent
+ * storage. It typically initializes the persistenceSignature member of the
+ * params to the MAGIC value to indicate persistence.
+ *
+ * @note: the save operation may be asynchronous. It may be a short while before
+ * the request takes affect. Reading back saved configParams may not yield
+ * correct behaviour if attempted soon after a store.
+ *
+ * @param[in/out] paramsP
+ *                    The params to be saved; persistenceSignature member gets
+ *                    updated if persistence is successful.
+ */
+void saveEddystoneServiceConfigParams(const EddystoneService::EddystoneParams_t *paramsP);
+
+#endif /* #ifndef __BLE_CONFIG_PARAMS_PERSISTENCE_H__*/
+
+#endif /* #ifdef TARGET_NRF51822 */

--- a/BLE_EddystoneService/source/nrfPersistentStorageHelper/nrfConfigParamsPersistence.cpp
+++ b/BLE_EddystoneService/source/nrfPersistentStorageHelper/nrfConfigParamsPersistence.cpp
@@ -1,0 +1,117 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef TARGET_NRF51822 /* Persistent storage supported on nrf51 platforms */
+
+extern "C" {
+    #include "pstorage.h"
+}
+
+#include "nrf_error.h"
+#include "ConfigParamsPersistence.h"
+
+/**
+ * Nordic specific structure used to store params persistently.
+ * It extends EddystoneService::EddystoneParams_t with a persistence signature.
+ */
+struct PersistentParams_t {
+    EddystoneService::EddystoneParams_t params;
+    uint32_t                         persistenceSignature; /* This isn't really a parameter, but having the expected
+                                                            * magic value in this field indicates persistence. */
+
+    static const uint32_t MAGIC = 0x1BEAC000;              /* Magic that identifies persistence */
+};
+
+/**
+ * The following is a module-local variable to hold configuration parameters for
+ * short periods during flash access. This is necessary because the pstorage
+ * APIs don't copy in the memory provided as data source. The memory cannot be
+ * freed or reused by the application until this flash access is complete. The
+ * load and store operations in this module initialize persistentParams and then
+ * pass it on to the 'pstorage' APIs.
+ */
+static PersistentParams_t persistentParams;
+
+static pstorage_handle_t pstorageHandle;
+
+/**
+ * Dummy callback handler needed by Nordic's pstorage module. This is called
+ * after every flash access.
+ */
+static void pstorageNotificationCallback(pstorage_handle_t *p_handle,
+                                         uint8_t            op_code,
+                                         uint32_t           result,
+                                         uint8_t           *p_data,
+                                         uint32_t           data_len)
+{
+    /* Supress compiler warnings */
+    (void) p_handle;
+    (void) op_code;
+    (void) result;
+    (void) p_data;
+    (void) data_len;
+
+    /* APP_ERROR_CHECK(result); */
+}
+
+/* Platform-specific implementation for persistence on the nRF5x. Based on the
+ * pstorage module provided by the Nordic SDK. */
+bool loadEddystoneServiceConfigParams(EddystoneService::EddystoneParams_t *paramsP)
+{
+    static bool pstorageInitied = false;
+    if (!pstorageInitied) {
+        pstorage_init();
+
+        static pstorage_module_param_t pstorageParams = {
+            .cb          = pstorageNotificationCallback,
+            .block_size  = sizeof(PersistentParams_t),
+            .block_count = 1
+        };
+        pstorage_register(&pstorageParams, &pstorageHandle);
+        pstorageInitied = true;
+    }
+
+    if ((pstorage_load(reinterpret_cast<uint8_t *>(&persistentParams), &pstorageHandle, sizeof(PersistentParams_t), 0) != NRF_SUCCESS) ||
+        (persistentParams.persistenceSignature != PersistentParams_t::MAGIC)) {
+        // On failure zero out and let the service reset to defaults
+        memset(paramsP, 0, sizeof(EddystoneService::EddystoneParams_t));
+        return false;
+    }
+
+    memcpy(paramsP, &persistentParams.params, sizeof(EddystoneService::EddystoneParams_t));
+    return true;
+}
+
+/* Platform-specific implementation for persistence on the nRF5x. Based on the
+ * pstorage module provided by the Nordic SDK. */
+void saveEddystoneServiceConfigParams(const EddystoneService::EddystoneParams_t *paramsP)
+{
+    memcpy(&persistentParams.params, paramsP, sizeof(EddystoneService::EddystoneParams_t));
+    if (persistentParams.persistenceSignature != PersistentParams_t::MAGIC) {
+        persistentParams.persistenceSignature = PersistentParams_t::MAGIC;
+        pstorage_store(&pstorageHandle,
+                       reinterpret_cast<uint8_t *>(&persistentParams),
+                       sizeof(PersistentParams_t),
+                       0 /* offset */);
+    } else {
+        pstorage_update(&pstorageHandle,
+                        reinterpret_cast<uint8_t *>(&persistentParams),
+                        sizeof(PersistentParams_t),
+                        0 /* offset */);
+    }
+}
+
+#endif /* #ifdef TARGET_NRF51822 */


### PR DESCRIPTION
Persistent storage for parameters is now supported in EddystoneService demo, yet this functionality is only enabled in nrf51-based devices. The demo will still compile and run without this functionality in other
platforms.