### PR TITLE
Cleanup eddystone code to not pass pointers

### DIFF
--- a/BLE_EddystoneService/source/EddystoneService.cpp
+++ b/BLE_EddystoneService/source/EddystoneService.cpp
@@ -161,21 +161,21 @@ EddystoneService::EddystoneError_t EddystoneService::startBeaconService(uint16_t
  * configured values that need to be stored and the main application
  * takes care of storing them.
  */
-void EddystoneService::getEddystoneParams(EddystoneParams_t *params)
+void EddystoneService::getEddystoneParams(EddystoneParams_t &params)
 {
-    params->lockState     = lockState;
-    params->flags         = flags;
-    params->txPowerMode   = txPowerMode;
-    params->beaconPeriod  = beaconPeriod;
-    params->tlmVersion    = tlmFrame.getTLMVersion();
-    params->urlDataLength = urlFrame.getEncodedURLDataLength();
+    params.lockState     = lockState;
+    params.flags         = flags;
+    params.txPowerMode   = txPowerMode;
+    params.beaconPeriod  = beaconPeriod;
+    params.tlmVersion    = tlmFrame.getTLMVersion();
+    params.urlDataLength = urlFrame.getEncodedURLDataLength();
 
-    memcpy(params->advPowerLevels, advPowerLevels,               sizeof(PowerLevels_t));
-    memcpy(params->lock,           lock,                         sizeof(Lock_t));
-    memcpy(params->unlock,         unlock,                       sizeof(Lock_t));
-    memcpy(params->urlData,        urlFrame.getEncodedURLData(), urlFrame.getEncodedURLDataLength());
-    memcpy(params->uidNamespaceID, uidFrame.getUIDNamespaceID(), sizeof(UIDNamespaceID_t));
-    memcpy(params->uidInstanceID,  uidFrame.getUIDInstanceID(),  sizeof(UIDInstanceID_t));
+    memcpy(params.advPowerLevels, advPowerLevels,               sizeof(PowerLevels_t));
+    memcpy(params.lock,           lock,                         sizeof(Lock_t));
+    memcpy(params.unlock,         unlock,                       sizeof(Lock_t));
+    memcpy(params.urlData,        urlFrame.getEncodedURLData(), urlFrame.getEncodedURLDataLength());
+    memcpy(params.uidNamespaceID, uidFrame.getUIDNamespaceID(), sizeof(UIDNamespaceID_t));
+    memcpy(params.uidInstanceID,  uidFrame.getUIDInstanceID(),  sizeof(UIDInstanceID_t));
 }
 
 /* Helper function used only once during constructing the object to avoid

--- a/BLE_EddystoneService/source/EddystoneService.h
+++ b/BLE_EddystoneService/source/EddystoneService.h
@@ -124,7 +124,7 @@ public:
      * configured values that need to be stored and the main application
      * takes care of storing them.
      */
-    void getEddystoneParams(EddystoneParams_t *params);
+    void getEddystoneParams(EddystoneParams_t &params);
 
 private:
     /* Helper function used only once during constructing the object to avoid

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -67,7 +67,7 @@ static void timeout(void)
         eddyServicePtr->startBeaconService(5, 5, 5);
 #ifdef TARGET_NRF51822
         EddystoneService::EddystoneParams_t params;
-        eddyServicePtr->getEddystoneParams(&params);
+        eddyServicePtr->getEddystoneParams(params);
         saveEddystoneServiceConfigParams(&params);
 #endif
     } else {


### PR DESCRIPTION
Clean up the eddystone example code to pass a EddystoneParams_t using a
reference to the structure rather than passing a pointer when calling
getEddystoneParams().
@pan- @rgrover 