### PR TITLE
Change Eddystone example frame scheduling

### DIFF
--- a/BLE_EddystoneService/source/EddystoneService.cpp
+++ b/BLE_EddystoneService/source/EddystoneService.cpp
@@ -28,6 +28,9 @@ EddystoneService::EddystoneService(BLE                 &bleIn,
     uidFrame(paramsIn.uidNamespaceID, paramsIn.uidInstanceID),
     tlmFrame(paramsIn.tlmVersion),
     resetFlag(false),
+    rawUrlFrame(NULL),
+    rawUidFrame(NULL),
+    rawTlmFrame(NULL),
     tlmBatteryVoltageCallback(NULL),
     tlmBeaconTemperatureCallback(NULL)
 {
@@ -65,6 +68,9 @@ EddystoneService::EddystoneService(BLE                 &bleIn,
     urlFramePeriod(DEFAULT_URL_FRAME_PERIOD_MSEC),
     uidFramePeriod(DEFAULT_UID_FRAME_PERIOD_MSEC),
     tlmFramePeriod(DEFAULT_TLM_FRAME_PERIOD_MSEC),
+    rawUrlFrame(NULL),
+    rawUidFrame(NULL),
+    rawTlmFrame(NULL),
     tlmBatteryVoltageCallback(NULL),
     tlmBeaconTemperatureCallback(NULL)
 {
@@ -360,9 +366,18 @@ void EddystoneService::freeConfigCharacteristics(void)
 
 void EddystoneService::freeBeaconFrames(void)
 {
-    delete[] rawUrlFrame;
-    delete[] rawUidFrame;
-    delete[] rawTlmFrame;
+    if (rawUrlFrame) {
+        delete[] rawUrlFrame;
+        rawUrlFrame = NULL;
+    }
+    if (rawUidFrame) {
+        delete[] rawUidFrame;
+        rawUidFrame = NULL;
+    }
+    if (rawtlmFrame) {
+        delete[] rawTlmFrame;
+        rawTlmFrame = NULL;
+    }
 }
 
 void EddystoneService::radioNotificationCallback(bool radioActive)

--- a/BLE_EddystoneService/source/EddystoneService.h
+++ b/BLE_EddystoneService/source/EddystoneService.h
@@ -34,8 +34,10 @@ class EddystoneService
 public:
     static const uint16_t TOTAL_CHARACTERISTICS = 9;
 
-    static const uint32_t DEFAULT_CONFIG_PERIOD_MSEC = 1000;
-    static const uint16_t DEFAULT_BEACON_PERIOD_MSEC = 1000;
+    static const uint32_t DEFAULT_CONFIG_PERIOD_MSEC    = 1000;
+    static const uint16_t DEFAULT_URL_FRAME_PERIOD_MSEC = 700;
+    static const uint16_t DEFAULT_UID_FRAME_PERIOD_MSEC = 300;
+    static const uint16_t DEFAULT_TLM_FRAME_PERIOD_MSEC = 2000;
 
     /* Operation modes of the EddystoneService:
      *      NONE: EddystoneService has been initialised but no memory has been
@@ -65,7 +67,9 @@ public:
         uint8_t          flags;
         PowerLevels_t    advPowerLevels;
         uint8_t          txPowerMode;
-        uint16_t         beaconPeriod;
+        uint16_t         urlFramePeriod;
+        uint16_t         uidFramePeriod;
+        uint16_t         tlmFramePeriod;
         uint8_t          tlmVersion;
         uint8_t          urlDataLength;
         UrlData_t        urlData;
@@ -204,7 +208,9 @@ private:
     Lock_t                                                          unlock;
     uint8_t                                                         flags;
     uint8_t                                                         txPowerMode;
-    uint16_t                                                        beaconPeriod;
+    uint16_t                                                        urlFramePeriod;
+    uint16_t                                                        uidFramePeriod;
+    uint16_t                                                        tlmFramePeriod;
 
     ReadOnlyGattCharacteristic<bool>                                *lockStateChar;
     WriteOnlyArrayGattCharacteristic<uint8_t, sizeof(Lock_t)>       *lockChar;

--- a/BLE_EddystoneService/source/EddystoneService.h
+++ b/BLE_EddystoneService/source/EddystoneService.h
@@ -92,6 +92,12 @@ public:
         NUM_EDDYSTONE_FRAMES
     };
 
+    /* WARNING: If the advertising rate for any of the frames is higher than
+     * 100ms then frames will be dropped, this value must be increased
+     */
+    static const uint16_t ADV_FRAME_QUEUE_SIZE = NUM_EDDYSTONE_FRAMES;
+
+
     /* Initialise the EddystoneService using parameters from persistent storage */
     EddystoneService(BLE                 &bleIn,
                      EddystoneParams_t   &paramsIn,
@@ -235,7 +241,7 @@ private:
     uint8_t                                                         *rawUidFrame;
     uint8_t                                                         *rawTlmFrame;
 
-    CircularBuffer<FrameType, NUM_EDDYSTONE_FRAMES>                 advFrameQueue;
+    CircularBuffer<FrameType, ADV_FRAME_QUEUE_SIZE>                 advFrameQueue;
 
     TlmUpdateCallback_t                                             tlmBatteryVoltageCallback;
     TlmUpdateCallback_t                                             tlmBeaconTemperatureCallback;

--- a/BLE_EddystoneService/source/EddystoneService.h
+++ b/BLE_EddystoneService/source/EddystoneService.h
@@ -119,6 +119,12 @@ public:
 
     void setUIDData(const UIDNamespaceID_t &uidNamespaceIDIn, const UIDInstanceID_t &uidInstanceIDIn);
 
+    void setURLFrameAdvertisingInterval(uint16_t urlFrameIntervalIn = DEFAULT_URL_FRAME_PERIOD_MSEC);
+
+    void setUIDFrameAdvertisingInterval(uint16_t uidFrameIntervalIn = DEFAULT_UID_FRAME_PERIOD_MSEC);
+
+    void setTLMFrameAdvertisingInterval(uint16_t tlmFrameIntervalIn = DEFAULT_TLM_FRAME_PERIOD_MSEC);
+
     EddystoneError_t startConfigService(void);
 
     EddystoneError_t startBeaconService(void);
@@ -165,7 +171,7 @@ private:
 
     void freeConfigCharacteristics(void);
 
-    void freeBeaconFrames(void);
+    void stopBeaconService(void);
 
     /*
      * Internal helper function used to update the GATT database following any
@@ -235,6 +241,11 @@ private:
     TlmUpdateCallback_t                                             tlmBeaconTemperatureCallback;
 
     Timer                                                           timeSinceBootTimer;
+
+    minar::callback_handle_t                                        uidFrameCallbackHandle;
+    minar::callback_handle_t                                        urlFrameCallbackHandle;
+    minar::callback_handle_t                                        tlmFrameCallbackHandle;
+    minar::callback_handle_t                                        radioManagerCallbackHandle;
 
     GattCharacteristic                                              *charTable[TOTAL_CHARACTERISTICS];
 };

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -25,7 +25,7 @@
 EddystoneService *eddyServicePtr;
 
 /* Duration after power-on that config service is available. */
-static const int CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS = 30;
+static const int CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS = 5;
 
 /* Default UID frame data */
 static const UIDNamespaceID_t uidNamespaceID = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};
@@ -64,7 +64,7 @@ static void timeout(void)
     Gap::GapState_t state;
     state = BLE::Instance().gap().getState();
     if (!state.connected) { /* don't switch if we're in a connected state. */
-        eddyServicePtr->startBeaconService(5, 5, 5);
+        eddyServicePtr->startBeaconService();
 #ifdef TARGET_NRF51822
         EddystoneService::EddystoneParams_t params;
         eddyServicePtr->getEddystoneParams(params);

--- a/BLE_EddystoneService/source/main.cpp
+++ b/BLE_EddystoneService/source/main.cpp
@@ -25,7 +25,7 @@
 EddystoneService *eddyServicePtr;
 
 /* Duration after power-on that config service is available. */
-static const int CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS = 5;
+static const int CONFIG_ADVERTISEMENT_TIMEOUT_SECONDS = 30;
 
 /* Default UID frame data */
 static const UIDNamespaceID_t uidNamespaceID = {0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99};


### PR DESCRIPTION
Change the scheduling of URL, TLM and UID frames to follow the specification recommendations. Instead of advertising X number of consecutive frames of the same type, it is now possible to set the advertisement interval of the individual frames. By default the intervals are:
* URL: 700ms
* UID: 300ms
* TML: 2000ms
Therefore, leaving the default values would produce the following advertisement packets:

0ms UID, TLM, URL packets are sent (they are actually sent at 100ms intervals as the BLE spec suggests)
300ms UID
600ms UID
700ms URL
900ms UID
and so on...

It also possible to configure this rated after the beacon mode has been set by calling the`set{URL|TLM|UID}FrameAdvertisingInterval()` functions. Notice that setting the interval to 0ms effectively turns off that particular frame.

The way to schedule advertisements has also a changed. The radio notification is no longer used, rather we schedule callbacks using minar and update the payload. Once the payload is updated the device is expected to retransmit the advertisement.

Finally, a set of other bugs were fixed:
* Memory that potentially was unallocated was freed when the beacon mode was stopped.
* Changed the correctAdvertisementPeriod() to use getMinNonConnectableAdvertisingInterval().

**NOTE:** This changes have not been profiled for power consumption.
@pan-