### PR TITLE
Improve BLE_LEDBlinker example.

### DIFF
--- a/BLE_LEDBlinker/readme.md
+++ b/BLE_LEDBlinker/readme.md
@@ -6,14 +6,14 @@ The example uses two applications running on two different devices:
 
 1. The first device - the central - runs the application ``BLE_LEDBlinker`` from this repository. This application sends an on/off toggle over BLE.
 
-1. The second device - the peripheral - runs the application [``BLE_LED``](https://github.com/ARMmbed/ble-examples/tree/master/BLE_LED) to respond to the toggle. 
+1. The second device - the peripheral - runs the application [``BLE_LED``](https://github.com/ARMmbed/ble-examples/tree/master/BLE_LED) to respond to the toggle.
 
 	The toggle simply turns the LED on the peripheral device on and off.
 
 # Running the application
 
 ## Requirements
- 
+
 Hardware requirements are in the [main readme](https://github.com/ARMmbed/ble-examples/blob/master/README.md).
 
 This example requires *two* devices.
@@ -22,7 +22,7 @@ This example requires *two* devices.
 
 You will need to build both applications and flash each one to a different board.
 
-Please note: The application ``BLE_LEDBlinker`` in this repository checks a device-specific parameter: ``peerAddr``. Before you build the application, you need to give this parameter the MAC address of your *peripheral* device (the device running the ``BLE_LED`` application).
+Please note: The application ``BLE_LEDBlinker`` in this repository initiate a connection to all ble devices which advertise "LED" as complete local name. By default, the application `BLE_LED` advertise "LED" as complete local name. If you change the local name advertised by the application `BLE_LED` you should reflect your change in this application by changing the value of the constant `PEER_NAME` in `main.cpp`.
 
 **Tip:** You may notice that the application also checks the LED characteristic's UUID; you don't need to change this parameter's value, because it already matches the UUID provided by the second application, ``BLE_LED``.
 
@@ -44,7 +44,7 @@ Building instructions for all mbed OS samples are in the [main readme](https://g
 
 ## Monitoring the application through a serial port
 
-You can run ``BLE_LEDBlinker`` and see that it works properly by monitoring its serial output. 
+You can run ``BLE_LEDBlinker`` and see that it works properly by monitoring its serial output.
 
 You need a terminal program to listen to the output through a serial port. You can download one, for example:
 
@@ -52,11 +52,10 @@ You need a terminal program to listen to the output through a serial port. You c
 * CoolTerm for Mac OS X.
 * GNU Screen for Linux.
 
-To see the application's output: 
+To see the application's output:
 
 1. Check which serial port your device is connected to.
-1. Check the baud rate of your device.
-1. Run a terminal program with the correct serial port and baud rate. For example, to use GNU Screen, run: ``screen /dev/tty.usbmodem1412 9600``.
-1. The application should start printing the toggle's value to the terminal. 
+1. Run a terminal program with the correct serial port and set the baud rate to 9600. For example, to use GNU Screen, run: ``screen /dev/tty.usbmodem1412 9600``.
+1. The application should start printing the toggle's value to the terminal.
 
-**Note:** ``BLE_LEDBlinker`` will not run properly if the ``BLE_LED`` application is not running on a second device. The terminal will show a few print statements, but you will not be able to see the application in full operation. 
+**Note:** ``BLE_LEDBlinker`` will not run properly if the ``BLE_LED`` application is not running on a second device. The terminal will show a few print statements, but you will not be able to see the application in full operation.


### PR DESCRIPTION
* Change the criteria used to identify the PEER. Instead of using the mac
address, the example now use the complete local name.
* Update the documentation.