### PR TITLE
Improve BLE_EddystoneObserver instructions.

### DIFF
--- a/BLE_EddystoneObserver/readme.md
+++ b/BLE_EddystoneObserver/readme.md
@@ -20,18 +20,16 @@ You need a terminal program to listen to the observer's output through a serial 
 
 Building instructions for all samples are in the [main readme](https://github.com/ARMmbed/ble-examples/blob/master/README.md).
 
-1. Build and run the [Eddystone beacon](https://github.com/ARMmbed/ble-examples/tree/master/BLE_EddystoneService) on one or more other devices. 
+1. Build and run the [Eddystone beacon](https://github.com/ARMmbed/ble-examples/tree/master/BLE_EddystoneService) on one or more other devices.
 
 1. Build the Eddystone Observer application and install it on your board as explained in the building instructions. Leave the board connected to your computer.
 
 ## Checking console output
 
-To see the application's output: 
+To see the application's output:
 
 1. Check which serial port your Eddystone Observer is connected to.
 
-1. Check the baud rate of your Eddystone Observer board.
+1. Run a terminal program with the correct serial port and the baud rate set to 9600. For example, to use GNU Screen, run: ``screen /dev/tty.usbmodem1412 9600``.
 
-1. Run a terminal program with the correct serial port and baud rate. For example, to use GNU Screen, run: ``screen /dev/tty.usbmodem1412 9600``.
-
-1. The Eddystone Observer should start printing URLs to the terminal. 
+1. The Eddystone Observer should start printing URLs to the terminal.


### PR DESCRIPTION
Indicate the baud rate used by the serial port.