### PR TITLE
Improve BLE_LEDBlinker example.

### DIFF
--- a/BLE_LEDBlinker/readme.md
+++ b/BLE_LEDBlinker/readme.md
@@ -32,15 +32,8 @@ Building instructions for all mbed OS samples are in the [main readme](https://g
 
 1. Build both applications and install one on each device, as explained in the building instructions.
 
-1. The device running ``BLE_LED`` should blink its LED.
+1. The LED number two of the device running ``BLE_LED`` should blink.
 
-1. You can change the blinking speed by changing the callback period in ``BLE_LEDBlinker``:
-
-	```
-	minar::Scheduler::postCallback(periodicCallback).period(minar::milliseconds(500));
-	```
-
-	Rebuild the application and flash it to the device. The second device's LED should update its blink speed.
 
 ## Monitoring the application through a serial port
 

--- a/BLE_LEDBlinker/source/main.cpp
+++ b/BLE_LEDBlinker/source/main.cpp
@@ -154,7 +154,10 @@ void bleInitComplete(BLE::InitializationCompleteCallbackContext *params)
     ble.gattClient().onDataRead(triggerToggledWrite);
     ble.gattClient().onDataWrite(triggerRead);
 
-    ble.gap().setScanParams(500, 400);
+    // scan interval: 400ms and scan window: 400ms.
+    // Every 400ms the device will scan for 400ms
+    // This means that the device will scan continuously.
+    ble.gap().setScanParams(400, 400);
     ble.gap().startScan(advertisementCallback);
 }
 


### PR DESCRIPTION
Remove the part of the instruction about the relationship betweeen the
periodic callback and the blink commands send to the peer device. It's
just false.

Use better scan params to catch the peer device immediately.